### PR TITLE
Extract solutions in a private method

### DIFF
--- a/goalie/adjoint.py
+++ b/goalie/adjoint.py
@@ -225,6 +225,8 @@ class AdjointMeshSeq(MeshSeq):
         """
         Extract adjoint solutions from the tape for a given subinterval.
 
+        :arg field: field to extract
+        :type field: :class:`str`
         :arg i: subinterval index
         :type i: :class:`int`
         :kwarg get_adj_values: if ``True``, adjoint actions are also returned at exported

--- a/goalie/mesh_seq.py
+++ b/goalie/mesh_seq.py
@@ -711,12 +711,6 @@ class MeshSeq:
         :kwarg return_blocks: if ``True``, returns solve blocks
         :type return_blocks: :class:`bool`
         """
-        stride = self.time_partition.num_timesteps_per_export[i]
-        num_exports = self.time_partition.num_exports_per_subinterval[i]
-
-        # # Loop over prognostic variables
-        # for field, fs in self.function_spaces.items():
-        fs = self.function_spaces[field]
         # Get solve blocks
         solve_blocks = self.get_solve_blocks(field, i)
         num_solve_blocks = len(solve_blocks)
@@ -725,14 +719,15 @@ class MeshSeq:
                 "Looks like no solves were written to tape!"
                 " Does the solution depend on the initial condition?"
             )
+        fs = self.function_spaces[field]
         if fs[0].ufl_element() != solve_blocks[0].function_space.ufl_element():
             raise ValueError(
                 f"Solve block list for field '{field}' contains mismatching"
                 f" finite elements: ({fs[0].ufl_element()} vs. "
                 f" {solve_blocks[0].function_space.ufl_element()})"
             )
-
-        # Extract solution data
+        stride = self.time_partition.num_timesteps_per_export[i]
+        num_exports = self.time_partition.num_exports_per_subinterval[i]
         if len(solve_blocks[::stride]) >= num_exports:
             raise ValueError(
                 f"More solve blocks than expected"


### PR DESCRIPTION
Closes #177. Partially addresses #142.

Also partially addresses #165 since it significantly simplifies `MeshSeq.solve_forward` and `AdjointMeshSeq.solve_adjoint`, and removes the current overlap in the code between them for extracting solutions.