### PR TITLE
Only run tests if .py files are changed in a commit

### DIFF
--- a/.github/workflows/citation_check.yml
+++ b/.github/workflows/citation_check.yml
@@ -1,0 +1,35 @@
+name: 'Citation Check'
+
+on:
+  # Run only when commits are pushed to a branch or a PR that modifies a .cff file
+  push:
+    paths:
+      - '**/*.cff'
+  pull_request:
+    paths:
+      - '**/*.cff'
+
+  # Allow manual triggering
+  workflow_dispatch:
+
+jobs:
+  citation_check:
+    name: 'Check Citation'
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/mesh-adaptation/firedrake-parmmg:latest
+      options: --user root
+
+    steps:
+      - name: 'Check out the repo'
+        uses: actions/checkout@v4
+
+      - name: 'Setup Python'
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
+      - name: 'Check citation'
+        run: |
+          . /home/firedrake/firedrake/bin/activate
+          make check_citation

--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -60,11 +60,6 @@ jobs:
           python -m pip uninstall -y goalie
           python -m pip install -e .
 
-      - name: 'Check citation'
-        run: |
-          . /home/firedrake/firedrake/bin/activate
-          make check_citation
-
       - name: 'Lint'
         if: ${{ (steps.changed-files.outputs.any_changed == 'true') || ( github.event_name == 'schedule') }}
         run: |

--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -37,6 +37,7 @@ jobs:
         uses: tj-actions/changed-files@v44
         with:
           files: |
+            .github/workflows/test_suite.yml
             *.py
             *.msh
             *.geo

--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -28,7 +28,18 @@ jobs:
       image: ghcr.io/mesh-adaptation/firedrake-parmmg:latest
       options: --user root
     steps:
-      - uses: actions/checkout@v2
+      - name: 'Check out the repo'
+        id: checkout
+        uses: actions/checkout@v4
+
+      - name: 'Determine files differing from target branch'
+        id: changed-files
+        uses: tj-actions/changed-files@v44
+        with:
+          files: |
+            *.py
+            *.msh
+            *.geo
 
       - name: 'Cleanup'
         if: ${{ always() }}
@@ -37,11 +48,13 @@ jobs:
           rm -rf build
 
       - name: 'Setup Python'
+        if: ${{ (steps.changed-files.outputs.any_changed == 'true') || ( github.event_name == 'schedule') }}
         uses: actions/setup-python@v2
         with:
           python-version: 3.8
 
       - name: 'Install Goalie'
+        if: ${{ (steps.changed-files.outputs.any_changed == 'true') || ( github.event_name == 'schedule') }}
         run: |
           . /home/firedrake/firedrake/bin/activate
           python -m pip uninstall -y goalie
@@ -53,12 +66,13 @@ jobs:
           make check_citation
 
       - name: 'Lint'
-        if: ${{ always() }}
+        if: ${{ (steps.changed-files.outputs.any_changed == 'true') || ( github.event_name == 'schedule') }}
         run: |
           . /home/firedrake/firedrake/bin/activate
           make lint
 
       - name: 'Test Goalie'
+        if: ${{ (steps.changed-files.outputs.any_changed == 'true') || ( github.event_name == 'schedule') }}
         run: |
           . /home/firedrake/firedrake/bin/activate
           python $(which firedrake-clean)


### PR DESCRIPTION
Closes #198

@jwallwork23 I went ahead with this before getting a green light from you first since it's quick and straightforward :) so I thought it's better to show you on here how it would work. But feel free to reject it of course!

I set it up so that https://github.com/tj-actions/changed-files looks for changed files since the last push, and if they include .py files then the testing suite is run. We also have one .geo and one .msh file so I suppose I should include those as well. Or more generally, I could set it up by directories: to run tests if changed files are in `/demos`, `/goalie`, `/goalie_adjoint` etc.