### PR TITLE
Shorten demos during testing outside of original scripts

### DIFF
--- a/demos/burgers-hessian.py
+++ b/demos/burgers-hessian.py
@@ -94,7 +94,7 @@ time_partition = TimePartition(
 params = MetricParameters(
     {
         "element_rtol": 0.001,
-        "maxiter": 35 if os.environ.get("GOALIE_REGRESSION_TEST") is None else 3,
+        "maxiter": 35,
     }
 )
 mesh_seq = MeshSeq(

--- a/demos/gray_scott.py
+++ b/demos/gray_scott.py
@@ -128,8 +128,7 @@ def get_qoi(mesh_seq, sols, index):
 # the timestep. This is straightforwardly done in Goalie using :class:`TimePartition`.
 # ::
 
-test = os.environ.get("GOALIE_REGRESSION_TEST") is not None
-end_time = 10.0 if test else 2000.0
+end_time = 2000.0
 dt = [0.0001, 0.001, 0.01, 0.1, (end_time - 1) / end_time]
 num_subintervals = 5
 dt_per_export = [10, 9, 9, 9, 10]
@@ -164,19 +163,18 @@ solutions = mesh_seq.solve_adjoint()
 
 # Finally, plot the outputs to be viewed in Paraview. ::
 
-if not test:
-    ic = mesh_seq.get_initial_condition()
-    for field, sols in solutions.items():
-        fwd_outfile = VTKFile(f"gray_scott/{field}_forward.pvd")
-        adj_outfile = VTKFile(f"gray_scott/{field}_adjoint.pvd")
-        fwd_outfile.write(*ic[field].subfunctions)
-        for i in range(num_subintervals):
-            for sol in sols["forward"][i]:
-                fwd_outfile.write(*sol.subfunctions)
-            for sol in sols["adjoint"][i]:
-                adj_outfile.write(*sol.subfunctions)
-        adj_end = Function(ic[field]).assign(0.0)
-        adj_outfile.write(*adj_end.subfunctions)
+ic = mesh_seq.get_initial_condition()
+for field, sols in solutions.items():
+    fwd_outfile = VTKFile(f"gray_scott/{field}_forward.pvd")
+    adj_outfile = VTKFile(f"gray_scott/{field}_adjoint.pvd")
+    fwd_outfile.write(*ic[field].subfunctions)
+    for i in range(num_subintervals):
+        for sol in sols["forward"][i]:
+            fwd_outfile.write(*sol.subfunctions)
+        for sol in sols["adjoint"][i]:
+            adj_outfile.write(*sol.subfunctions)
+    adj_end = Function(ic[field]).assign(0.0)
+    adj_outfile.write(*adj_end.subfunctions)
 
 # In the `next demo <./gray_scott_split.py.html>`__, we consider solving the same
 # problem, but splitting the solution field into multiple components.

--- a/demos/gray_scott_split.py
+++ b/demos/gray_scott_split.py
@@ -137,8 +137,7 @@ def get_qoi(mesh_seq, sols, index):
     return qoi
 
 
-test = os.environ.get("GOALIE_REGRESSION_TEST") is not None
-end_time = 10.0 if test else 2000.0
+end_time = 2000.0
 dt = [0.0001, 0.001, 0.01, 0.1, (end_time - 1) / end_time]
 num_subintervals = 5
 dt_per_export = [10, 9, 9, 9, 10]
@@ -169,17 +168,16 @@ mesh_seq = AdjointMeshSeq(
 )
 solutions = mesh_seq.solve_adjoint()
 
-if not test:
-    ic = mesh_seq.get_initial_condition()
-    for field, sols in solutions.items():
-        fwd_outfile = VTKFile(f"gray_scott_split/{field}_forward.pvd")
-        adj_outfile = VTKFile(f"gray_scott_split/{field}_adjoint.pvd")
-        fwd_outfile.write(ic[field])
-        for i in range(num_subintervals):
-            for sol in sols["forward"][i]:
-                fwd_outfile.write(sol)
-            for sol in sols["adjoint"][i]:
-                adj_outfile.write(sol)
-        adj_outfile.write(Function(ic[field]).assign(0.0))
+ic = mesh_seq.get_initial_condition()
+for field, sols in solutions.items():
+    fwd_outfile = VTKFile(f"gray_scott_split/{field}_forward.pvd")
+    adj_outfile = VTKFile(f"gray_scott_split/{field}_adjoint.pvd")
+    fwd_outfile.write(ic[field])
+    for i in range(num_subintervals):
+        for sol in sols["forward"][i]:
+            fwd_outfile.write(sol)
+        for sol in sols["adjoint"][i]:
+            adj_outfile.write(sol)
+    adj_outfile.write(Function(ic[field]).assign(0.0))
 
 # This tutorial can be dowloaded as a `Python script <gray_scott_split.py>`__.

--- a/demos/point_discharge2d-goal_oriented.py
+++ b/demos/point_discharge2d-goal_oriented.py
@@ -104,7 +104,7 @@ params = GoalOrientedMetricParameters(
     {
         "element_rtol": 0.005,
         "qoi_rtol": 0.005,
-        "maxiter": 35 if os.environ.get("GOALIE_REGRESSION_TEST") is None else 3,
+        "maxiter": 35,
     }
 )
 

--- a/demos/point_discharge2d-hessian.py
+++ b/demos/point_discharge2d-hessian.py
@@ -100,7 +100,7 @@ def get_solver(mesh_seq):
 params = MetricParameters(
     {
         "element_rtol": 0.005,
-        "maxiter": 35 if os.environ.get("GOALIE_REGRESSION_TEST") is None else 3,
+        "maxiter": 35,
     }
 )
 

--- a/demos/solid_body_rotation.py
+++ b/demos/solid_body_rotation.py
@@ -93,12 +93,9 @@ def get_initial_condition(mesh_seq):
     return {"c": assemble(interpolate(bell + cone + slot_cyl, fs))}
 
 
-# Now let's set up the time interval of interest. The `"GOALIE_REGRESSION_TEST"` flag
-# can be ignored here and in subsequent demos; it is used to cut down the runtime in
-# Goalie's continuous integration suite. ::
+# Now let's set up the time interval of interest. ::
 
-test = os.environ.get("GOALIE_REGRESSION_TEST") is not None
-end_time = pi / 4 if test else 2 * pi
+end_time = 2 * pi
 dt = pi / 300
 time_partition = TimeInterval(
     end_time,
@@ -241,18 +238,16 @@ solutions = mesh_seq.solve_adjoint()
 
 # So far, we have visualised outputs using `Matplotlib`. In many cases, it is better to
 # use Paraview. To save all adjoint solution components in Paraview format, use the
-# following. The `if` statement is used here to check whether this demo is being run as
-# part of Goalie's continuous integration testing and can be ignored. ::
+# following. ::
 
-if not test:
-    for field, sols in solutions.items():
-        fwd_outfile = VTKFile(f"solid_body_rotation/{field}_forward.pvd")
-        adj_outfile = VTKFile(f"solid_body_rotation/{field}_adjoint.pvd")
-        for i in range(len(mesh_seq)):
-            for sol in sols["forward"][i]:
-                fwd_outfile.write(sol)
-            for sol in sols["adjoint"][i]:
-                adj_outfile.write(sol)
+for field, sols in solutions.items():
+    fwd_outfile = VTKFile(f"solid_body_rotation/{field}_forward.pvd")
+    adj_outfile = VTKFile(f"solid_body_rotation/{field}_adjoint.pvd")
+    for i in range(len(mesh_seq)):
+        for sol in sols["forward"][i]:
+            fwd_outfile.write(sol)
+        for sol in sols["adjoint"][i]:
+            adj_outfile.write(sol)
 
 # In the `next demo <./gray_scott.py.html>`__, we increase the complexity by considering
 # two concentration fields in an advection-diffusion-reaction problem.

--- a/test_adjoint/test_demos.py
+++ b/test_adjoint/test_demos.py
@@ -5,19 +5,71 @@ Checks that all demo scripts run.
 import glob
 import os
 import shutil
-import subprocess
-import sys
 from os.path import splitext
 
 import pytest
 
-# Set environment variable to specify that tests are being run so that we can
-# cut down the length of the demos
-os.environ["GOALIE_REGRESSION_TEST"] = "1"
-
 cwd = os.path.abspath(os.path.dirname(__file__))
 demo_dir = os.path.abspath(os.path.join(cwd, "..", "demos"))
 all_demos = glob.glob(os.path.join(demo_dir, "*.py"))
+
+# Modifications dictionary to cut down run time of demos:
+# - Each key is the name of a demo script to be modified
+# - Each value is a dictionary where:
+# -- The key is the original string or block of code to be replaced
+# -- The value is the replacement string (use "" to remove the original code)
+modifications = {
+    "burgers_hessian.py": {"'maxiter': 35": "'maxiter': 3"},
+    "gray_scott.py": {
+        "end_time = 2000.0": "end_time = 10.0",
+        """
+        ic = mesh_seq.get_initial_condition()
+        for field, sols in solutions.items():
+            fwd_outfile = VTKFile(f"gray_scott/{field}_forward.pvd")
+            adj_outfile = VTKFile(f"gray_scott/{field}_adjoint.pvd")
+            fwd_outfile.write(*ic[field].subfunctions)
+            for i in range(num_subintervals):
+                for sol in sols["forward"][i]:
+                    fwd_outfile.write(*sol.subfunctions)
+                for sol in sols["adjoint"][i]:
+                    adj_outfile.write(*sol.subfunctions)
+            adj_end = Function(ic[field]).assign(0.0)
+            adj_outfile.write(*adj_end.subfunctions)
+        """: "",
+    },
+    "gray_scott_split.py": {
+        "end_time = 2000.0": "end_time = 10.0",
+        """
+        ic = mesh_seq.get_initial_condition()
+        for field, sols in solutions.items():
+            fwd_outfile = VTKFile(f"gray_scott/{field}_forward.pvd")
+            adj_outfile = VTKFile(f"gray_scott/{field}_adjoint.pvd")
+            fwd_outfile.write(*ic[field].subfunctions)
+            for i in range(num_subintervals):
+                for sol in sols["forward"][i]:
+                    fwd_outfile.write(*sol.subfunctions)
+                for sol in sols["adjoint"][i]:
+                    adj_outfile.write(*sol.subfunctions)
+            adj_end = Function(ic[field]).assign(0.0)
+            adj_outfile.write(*adj_end.subfunctions)
+        """: "",
+    },
+    "point_discharge2d-hessian.py": {"'maxiter': 35": "'maxiter': 3"},
+    "point_discharge2d-goal_oriented.py": {"'maxiter': 35": "'maxiter': 3"},
+    "solid_body_rotation.py": {
+        "end_time = 2 * pi": "end_time = pi / 4",
+        """
+        for field, sols in solutions.items():
+            fwd_outfile = VTKFile(f"solid_body_rotation/{field}_forward.pvd")
+            adj_outfile = VTKFile(f"solid_body_rotation/{field}_adjoint.pvd")
+            for i in range(len(mesh_seq)):
+                for sol in sols["forward"][i]:
+                    fwd_outfile.write(sol)
+                for sol in sols["adjoint"][i]:
+                    adj_outfile.write(sol)
+        """: "",
+    },
+}
 
 
 @pytest.fixture(params=all_demos, ids=lambda x: splitext(x.split("demos/")[-1])[0])
@@ -35,8 +87,26 @@ def test_demos(demo_file, tmpdir, monkeypatch):
 
     # Change working directory to temporary directory
     monkeypatch.chdir(tmpdir)
-    subprocess.check_call([sys.executable, demo_file])
+
+    # Read the original demo script
+    with open(demo_file, "r") as f:
+        demo_contents = f.read()
+
+    # Modify the demo script to shorten run time
+    demo_name = os.path.basename(demo_file)
+    if demo_name in modifications:
+        for original, replacement in modifications[demo_name].items():
+            demo_contents = demo_contents.replace(original, replacement)
+
+    # Execute the modified demo as a standalone script
+    context = {
+        "__file__": demo_file,
+        "__name__": "__main__",
+        "__package__": None,
+    }
+    exec(demo_contents, context)
 
     # Clean up plots
     for ext in ("jpg", "pvd", "vtu"):
-        subprocess.check_call(["rm", "-f", f"*.{ext}"])
+        for f in glob.glob(f"*.{ext}"):
+            os.remove(f)

--- a/test_adjoint/test_demos.py
+++ b/test_adjoint/test_demos.py
@@ -18,56 +18,58 @@ all_demos = glob.glob(os.path.join(demo_dir, "*.py"))
 # - Each value is a dictionary where:
 # -- The key is the original string or block of code to be replaced
 # -- The value is the replacement string (use "" to remove the original code)
+gray_scott_block = """
+ic = mesh_seq.get_initial_condition()
+for field, sols in solutions.items():
+    fwd_outfile = VTKFile(f"gray_scott/{field}_forward.pvd")
+    adj_outfile = VTKFile(f"gray_scott/{field}_adjoint.pvd")
+    fwd_outfile.write(*ic[field].subfunctions)
+    for i in range(num_subintervals):
+        for sol in sols["forward"][i]:
+            fwd_outfile.write(*sol.subfunctions)
+        for sol in sols["adjoint"][i]:
+            adj_outfile.write(*sol.subfunctions)
+    adj_end = Function(ic[field]).assign(0.0)
+    adj_outfile.write(*adj_end.subfunctions)
+"""
+gray_scott_split_block = """
+ic = mesh_seq.get_initial_condition()
+for field, sols in solutions.items():
+    fwd_outfile = VTKFile(f"gray_scott_split/{field}_forward.pvd")
+    adj_outfile = VTKFile(f"gray_scott_split/{field}_adjoint.pvd")
+    fwd_outfile.write(ic[field])
+    for i in range(num_subintervals):
+        for sol in sols["forward"][i]:
+            fwd_outfile.write(sol)
+        for sol in sols["adjoint"][i]:
+            adj_outfile.write(sol)
+    adj_outfile.write(Function(ic[field]).assign(0.0))
+"""
+solid_body_rotation_block = """
+for field, sols in solutions.items():
+    fwd_outfile = VTKFile(f"solid_body_rotation/{field}_forward.pvd")
+    adj_outfile = VTKFile(f"solid_body_rotation/{field}_adjoint.pvd")
+    for i in range(len(mesh_seq)):
+        for sol in sols["forward"][i]:
+            fwd_outfile.write(sol)
+        for sol in sols["adjoint"][i]:
+            adj_outfile.write(sol)
+"""
+
 modifications = {
-    "burgers-hessian.py": {"'maxiter': 35": "'maxiter': 3"},
+    "burgers-hessian.py": {""""maxiter": 35""": """"maxiter": 3"""},
     "gray_scott.py": {
         "end_time = 2000.0": "end_time = 10.0",
-        """
-        ic = mesh_seq.get_initial_condition()
-        for field, sols in solutions.items():
-            fwd_outfile = VTKFile(f"gray_scott/{field}_forward.pvd")
-            adj_outfile = VTKFile(f"gray_scott/{field}_adjoint.pvd")
-            fwd_outfile.write(*ic[field].subfunctions)
-            for i in range(num_subintervals):
-                for sol in sols["forward"][i]:
-                    fwd_outfile.write(*sol.subfunctions)
-                for sol in sols["adjoint"][i]:
-                    adj_outfile.write(*sol.subfunctions)
-            adj_end = Function(ic[field]).assign(0.0)
-            adj_outfile.write(*adj_end.subfunctions)
-        """: "",
+        gray_scott_block: "",
     },
     "gray_scott_split.py": {
         "end_time = 2000.0": "end_time = 10.0",
-        """
-        ic = mesh_seq.get_initial_condition()
-        for field, sols in solutions.items():
-            fwd_outfile = VTKFile(f"gray_scott/{field}_forward.pvd")
-            adj_outfile = VTKFile(f"gray_scott/{field}_adjoint.pvd")
-            fwd_outfile.write(*ic[field].subfunctions)
-            for i in range(num_subintervals):
-                for sol in sols["forward"][i]:
-                    fwd_outfile.write(*sol.subfunctions)
-                for sol in sols["adjoint"][i]:
-                    adj_outfile.write(*sol.subfunctions)
-            adj_end = Function(ic[field]).assign(0.0)
-            adj_outfile.write(*adj_end.subfunctions)
-        """: "",
+        gray_scott_split_block: "",
     },
-    "point_discharge2d-hessian.py": {"'maxiter': 35": "'maxiter': 3"},
-    "point_discharge2d-goal_oriented.py": {"'maxiter': 35": "'maxiter': 3"},
+    "point_discharge2d-hessian.py": {""""maxiter": 35""": """"maxiter": 3"""},
+    "point_discharge2d-goal_oriented.py": {""""maxiter": 35""": """"maxiter": 3"""},
     "solid_body_rotation.py": {
-        "end_time = 2 * pi": "end_time = pi / 4",
-        """
-        for field, sols in solutions.items():
-            fwd_outfile = VTKFile(f"solid_body_rotation/{field}_forward.pvd")
-            adj_outfile = VTKFile(f"solid_body_rotation/{field}_adjoint.pvd")
-            for i in range(len(mesh_seq)):
-                for sol in sols["forward"][i]:
-                    fwd_outfile.write(sol)
-                for sol in sols["adjoint"][i]:
-                    adj_outfile.write(sol)
-        """: "",
+        solid_body_rotation_block: "",
     },
 }
 
@@ -77,14 +79,13 @@ def demo_file(request):
     return os.path.abspath(request.param)
 
 
-def test_modifications_exist():
+def test_modifications_demo_exists():
     """
     Check that all demos named in the modifications dictionary exist in the 'demos' dir.
     """
-
     for demo_name in modifications.keys():
         demo_fpath = os.path.join(demo_dir, demo_name)
-        assert demo_fpath in all_demos, f"Demo '{demo_name}' not found."
+        assert demo_fpath in all_demos, f"Error: Demo '{demo_name}' not found."
 
 
 def test_demos(demo_file, tmpdir, monkeypatch):

--- a/test_adjoint/test_demos.py
+++ b/test_adjoint/test_demos.py
@@ -88,6 +88,21 @@ def test_modifications_demo_exists():
         assert demo_fpath in all_demos, f"Error: Demo '{demo_name}' not found."
 
 
+def test_modifications_original_exists():
+    """
+    Check that all 'original' code snippets in the modifications dictionary exist in the
+    corresponding demo scripts.
+    """
+    for demo_name, changes in modifications.items():
+        demo_path = os.path.join(demo_dir, demo_name)
+        with open(demo_path, "r") as file:
+            demo_content = file.read()
+            for original in changes.keys():
+                assert (
+                    original in demo_content
+                ), f"Error: '{original}' not found in '{demo_name}'."
+
+
 def test_demos(demo_file, tmpdir, monkeypatch):
     assert os.path.isfile(demo_file), f"Demo file '{demo_file}' not found."
 

--- a/test_adjoint/test_demos.py
+++ b/test_adjoint/test_demos.py
@@ -77,6 +77,16 @@ def demo_file(request):
     return os.path.abspath(request.param)
 
 
+def test_modifications_exist():
+    """
+    Check that all demos named in the modifications dictionary exist in the 'demos' dir.
+    """
+
+    for demo_name in modifications.keys():
+        demo_fpath = os.path.join(demo_dir, demo_name)
+        assert demo_fpath in all_demos, f"Demo '{demo_name}' not found."
+
+
 def test_demos(demo_file, tmpdir, monkeypatch):
     assert os.path.isfile(demo_file), f"Demo file '{demo_file}' not found."
 

--- a/test_adjoint/test_demos.py
+++ b/test_adjoint/test_demos.py
@@ -19,7 +19,7 @@ all_demos = glob.glob(os.path.join(demo_dir, "*.py"))
 # -- The key is the original string or block of code to be replaced
 # -- The value is the replacement string (use "" to remove the original code)
 modifications = {
-    "burgers_hessian.py": {"'maxiter': 35": "'maxiter': 3"},
+    "burgers-hessian.py": {"'maxiter': 35": "'maxiter': 3"},
     "gray_scott.py": {
         "end_time = 2000.0": "end_time = 10.0",
         """

--- a/test_adjoint/test_demos.py
+++ b/test_adjoint/test_demos.py
@@ -10,6 +10,8 @@ from os.path import splitext
 
 import pytest
 
+from goalie.log import *
+
 cwd = os.path.abspath(os.path.dirname(__file__))
 demo_dir = os.path.abspath(os.path.join(cwd, "..", "demos"))
 all_demos = glob.glob(os.path.join(demo_dir, "*.py"))
@@ -89,13 +91,16 @@ def test_demos(demo_file, tmpdir, monkeypatch):
                 original, replacement, demo_contents, flags=re.DOTALL
             )
 
-    # Execute the modified demo as a standalone script
-    context = {
+    # Execute the modified demo as a standalone script in a clean namespace
+    exec_namespace = {
         "__file__": demo_file,
         "__name__": "__main__",
         "__package__": None,
     }
-    exec(demo_contents, context)
+    exec(demo_contents, exec_namespace)
+
+    # Reset log level
+    set_log_level(WARNING)
 
     # Clean up plots
     for ext in ("jpg", "pvd", "vtu"):

--- a/test_adjoint/test_demos.py
+++ b/test_adjoint/test_demos.py
@@ -4,6 +4,7 @@ Checks that all demo scripts run.
 
 import glob
 import os
+import re
 import shutil
 from os.path import splitext
 
@@ -16,60 +17,22 @@ all_demos = glob.glob(os.path.join(demo_dir, "*.py"))
 # Modifications dictionary to cut down run time of demos:
 # - Each key is the name of a demo script to be modified
 # - Each value is a dictionary where:
-# -- The key is the original string or block of code to be replaced
+# -- The key is the original string or regex pattern that we wish to replace
 # -- The value is the replacement string (use "" to remove the original code)
-gray_scott_block = """
-ic = mesh_seq.get_initial_condition()
-for field, sols in solutions.items():
-    fwd_outfile = VTKFile(f"gray_scott/{field}_forward.pvd")
-    adj_outfile = VTKFile(f"gray_scott/{field}_adjoint.pvd")
-    fwd_outfile.write(*ic[field].subfunctions)
-    for i in range(num_subintervals):
-        for sol in sols["forward"][i]:
-            fwd_outfile.write(*sol.subfunctions)
-        for sol in sols["adjoint"][i]:
-            adj_outfile.write(*sol.subfunctions)
-    adj_end = Function(ic[field]).assign(0.0)
-    adj_outfile.write(*adj_end.subfunctions)
-"""
-gray_scott_split_block = """
-ic = mesh_seq.get_initial_condition()
-for field, sols in solutions.items():
-    fwd_outfile = VTKFile(f"gray_scott_split/{field}_forward.pvd")
-    adj_outfile = VTKFile(f"gray_scott_split/{field}_adjoint.pvd")
-    fwd_outfile.write(ic[field])
-    for i in range(num_subintervals):
-        for sol in sols["forward"][i]:
-            fwd_outfile.write(sol)
-        for sol in sols["adjoint"][i]:
-            adj_outfile.write(sol)
-    adj_outfile.write(Function(ic[field]).assign(0.0))
-"""
-solid_body_rotation_block = """
-for field, sols in solutions.items():
-    fwd_outfile = VTKFile(f"solid_body_rotation/{field}_forward.pvd")
-    adj_outfile = VTKFile(f"solid_body_rotation/{field}_adjoint.pvd")
-    for i in range(len(mesh_seq)):
-        for sol in sols["forward"][i]:
-            fwd_outfile.write(sol)
-        for sol in sols["adjoint"][i]:
-            adj_outfile.write(sol)
-"""
-
 modifications = {
     "burgers-hessian.py": {""""maxiter": 35""": """"maxiter": 3"""},
     "gray_scott.py": {
         "end_time = 2000.0": "end_time = 10.0",
-        gray_scott_block: "",
+        r"ic = mesh_seq.get_initial_condition\(\)\n.*?adj_outfile.write\(\*adj_end.subfunctions\)": "",
     },
     "gray_scott_split.py": {
         "end_time = 2000.0": "end_time = 10.0",
-        gray_scott_split_block: "",
+        r"ic = mesh_seq.get_initial_condition\(\)\n.*?adj_outfile.write\(Function\(ic\[field\]\).assign\(0.0\)\)": "",
     },
     "point_discharge2d-hessian.py": {""""maxiter": 35""": """"maxiter": 3"""},
     "point_discharge2d-goal_oriented.py": {""""maxiter": 35""": """"maxiter": 3"""},
     "solid_body_rotation.py": {
-        solid_body_rotation_block: "",
+        r"for field, sols in solutions.items\(\):\n.*?adj_outfile.write\(sol\)": "",
     },
 }
 
@@ -98,8 +61,8 @@ def test_modifications_original_exists():
         with open(demo_path, "r") as file:
             demo_content = file.read()
             for original in changes.keys():
-                assert (
-                    original in demo_content
+                assert re.search(
+                    original, demo_content, re.DOTALL
                 ), f"Error: '{original}' not found in '{demo_name}'."
 
 
@@ -122,7 +85,9 @@ def test_demos(demo_file, tmpdir, monkeypatch):
     demo_name = os.path.basename(demo_file)
     if demo_name in modifications:
         for original, replacement in modifications[demo_name].items():
-            demo_contents = demo_contents.replace(original, replacement)
+            demo_contents = re.sub(
+                original, replacement, demo_contents, flags=re.DOTALL
+            )
 
     # Execute the modified demo as a standalone script
     context = {


### PR DESCRIPTION
Closes #173. Closes #175.

This PR:
- runs the demos directly in `test_demos.py` instead of using `subprocess`, so that demos contribute properly to the coverage report
- modifies the demos inside `test_demos.py` to cut down run time, instead of exporting a global environment variable that is then used inside demos in an `if` statement

@jwallwork23 you said that we can take over issues without asking, so I hope you don't mind that I did :) 

