### PR TITLE
Enable C linting rules (excl C901)

### DIFF
--- a/goalie/mesh_seq.py
+++ b/goalie/mesh_seq.py
@@ -53,10 +53,7 @@ class MeshSeq:
         """
         self.time_partition = time_partition
         self.fields = {field_name: None for field_name in time_partition.field_names}
-        self.field_types = {
-            field: field_type
-            for field, field_type in zip(self.fields, time_partition.field_types)
-        }
+        self.field_types = dict(zip(self.fields, time_partition.field_types))
         self.subintervals = time_partition.subintervals
         self.num_subintervals = time_partition.num_subintervals
         self.set_meshes(initial_meshes)

--- a/goalie/options.py
+++ b/goalie/options.py
@@ -80,7 +80,7 @@ class AdaptParameters(AttrDict):
             )
 
     def __str__(self):
-        return str({key: value for key, value in self.items()})
+        return str(dict(self.items()))
 
     def __repr__(self):
         d = ", ".join([f"{key}={value}" for key, value in self.items()])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,12 +45,13 @@ line-length = 88
 [tool.ruff.lint]
 select = [
   "B",  # flake8-bugbear
-#  "C",  # mccabe complexity  TODO: enable this (#165)
+  "C",  # mccabe complexity
   "E", "W",  # Pycodestyle
   "F",  # Pyflakes
   "I",  # isort
 ]
 ignore = [
+  "C901",  # function is too complex (TODO #165: enable this)
   "E501",  # line too long
   "E203",  # whitespace before ':'
   "E226",  # missing whitespace around arithmetic operator

--- a/test/test_mesh_seq.py
+++ b/test/test_mesh_seq.py
@@ -54,7 +54,7 @@ class TestGeneric(unittest.TestCase):
         funcs = [lambda _: 0, lambda _: 0, lambda _: lambda *_: 0]
         methods_map = dict(zip(methods, funcs))
         if method == "get_form":
-            kwargs = {method: func for method, func in methods_map.items()}
+            kwargs = methods_map
             f_space = FunctionSpace(mesh, "CG", 1)
             kwargs["get_function_spaces"] = lambda _: {"field": f_space}
             kwargs["get_initial_condition"] = lambda _: {"field": Function(f_space)}


### PR DESCRIPTION
Partially addresses #165.

I enabled C linting rules but added C901 ("function is too complex") to the ignore list. I addressed the easy errors, but addressing C901 errors requires more thought/time and these functions are anyway all likely going to be reorganised (soon?) as per our discussion in #189. 