### PR TITLE
Do not require `get_form` in user code

### DIFF
--- a/demos/burgers-hessian.py
+++ b/demos/burgers-hessian.py
@@ -23,8 +23,8 @@ def get_function_spaces(mesh):
     return {"u": VectorFunctionSpace(mesh, "CG", 2)}
 
 
-def get_form(mesh_seq):
-    def form(index):
+def get_solver(mesh_seq):
+    def solver(index):
         u, u_ = mesh_seq.fields["u"]
 
         # Define constants
@@ -39,17 +39,6 @@ def get_form(mesh_seq):
             + inner(dot(u, nabla_grad(u)), v) * dx
             + nu * inner(grad(u), grad(v)) * dx
         )
-        return {"u": F}
-
-    return form
-
-
-def get_solver(mesh_seq):
-    def solver(index):
-        u, u_ = mesh_seq.fields["u"]
-
-        # Define form
-        F = mesh_seq.form(index)["u"]
 
         # Time integrate from t_start to t_end
         tp = mesh_seq.time_partition
@@ -91,7 +80,6 @@ mesh_seq = MeshSeq(
     meshes,
     get_function_spaces=get_function_spaces,
     get_initial_condition=get_initial_condition,
-    get_form=get_form,
     get_solver=get_solver,
 )
 

--- a/demos/burgers1.py
+++ b/demos/burgers1.py
@@ -15,7 +15,7 @@ from firedrake import *
 from goalie_adjoint import *
 
 # For ease, the list of field names and functions for obtaining the
-# function spaces, forms, solvers, and initial conditions
+# function spaces, solvers, and initial conditions
 # are redefined as in the previous demo. The only difference
 # is that now we are solving the adjoint problem, which
 # requires that the PDE solve is labelled with an
@@ -29,8 +29,8 @@ def get_function_spaces(mesh):
     return {"u": VectorFunctionSpace(mesh, "CG", 2)}
 
 
-def get_form(mesh_seq):
-    def form(index):
+def get_solver(mesh_seq):
+    def solver(index):
         u, u_ = mesh_seq.fields["u"]
 
         # Define constants
@@ -45,17 +45,6 @@ def get_form(mesh_seq):
             + inner(dot(u, nabla_grad(u)), v) * dx
             + nu * inner(grad(u), grad(v)) * dx
         )
-        return {"u": F}
-
-    return form
-
-
-def get_solver(mesh_seq):
-    def solver(index):
-        u, u_ = mesh_seq.fields["u"]
-
-        # Define form
-        F = mesh_seq.form(index)["u"]
 
         # Time integrate from t_start to t_end
         tp = mesh_seq.time_partition
@@ -125,7 +114,6 @@ mesh_seq = AdjointMeshSeq(
     mesh,
     get_function_spaces=get_function_spaces,
     get_initial_condition=get_initial_condition,
-    get_form=get_form,
     get_solver=get_solver,
     get_qoi=get_qoi,
     qoi_type="end_time",

--- a/demos/burgers2.py
+++ b/demos/burgers2.py
@@ -24,8 +24,8 @@ def get_function_spaces(mesh):
     return {"u": VectorFunctionSpace(mesh, "CG", 2)}
 
 
-def get_form(mesh_seq):
-    def form(index):
+def get_solver(mesh_seq):
+    def solver(index):
         u, u_ = mesh_seq.fields["u"]
 
         # Define constants
@@ -40,17 +40,6 @@ def get_form(mesh_seq):
             + inner(dot(u, nabla_grad(u)), v) * dx
             + nu * inner(grad(u), grad(v)) * dx
         )
-        return {"u": F}
-
-    return form
-
-
-def get_solver(mesh_seq):
-    def solver(index):
-        u, u_ = mesh_seq.fields["u"]
-
-        # Define form
-        F = mesh_seq.form(index)["u"]
 
         # Time integrate from t_start to t_end
         tp = mesh_seq.time_partition
@@ -105,7 +94,6 @@ mesh_seq = AdjointMeshSeq(
     meshes,
     get_function_spaces=get_function_spaces,
     get_initial_condition=get_initial_condition,
-    get_form=get_form,
     get_solver=get_solver,
     get_qoi=get_qoi,
     qoi_type="end_time",

--- a/demos/burgers_oo.py
+++ b/demos/burgers_oo.py
@@ -30,8 +30,8 @@ class BurgersMeshSeq(GoalOrientedMeshSeq):
     def get_function_spaces(mesh):
         return {"u": VectorFunctionSpace(mesh, "CG", 2)}
 
-    def get_form(self):
-        def form(index):
+    def get_solver(self):
+        def solver(index):
             u, u_ = self.fields["u"]
 
             # Define constants
@@ -46,16 +46,9 @@ class BurgersMeshSeq(GoalOrientedMeshSeq):
                 + inner(dot(u, nabla_grad(u)), v) * dx
                 + nu * inner(grad(u), grad(v)) * dx
             )
-            return {"u": F}
 
-        return form
-
-    def get_solver(self):
-        def solver(index):
-            u, u_ = self.fields["u"]
-
-            # Define form
-            F = self.form(index)["u"]
+            # Communicate variational form to mesh_seq
+            self.read_forms({"u": F})
 
             # Time integrate from t_start to t_end
             t_start, t_end = self.subintervals[index]

--- a/demos/burgers_time_integrated.py
+++ b/demos/burgers_time_integrated.py
@@ -12,33 +12,12 @@ from firedrake import *
 
 from goalie_adjoint import *
 
-# Redefine the ``get_initial_condition``, ``get_function_spaces``,
-# and ``get_form`` functions as in the first Burgers demo. ::
+# Redefine the ``get_initial_condition`` and ``get_function_spaces``,
+# functions as in the first Burgers demo. ::
 
 
 def get_function_spaces(mesh):
     return {"u": VectorFunctionSpace(mesh, "CG", 2)}
-
-
-def get_form(mesh_seq):
-    def form(index):
-        u, u_ = mesh_seq.fields["u"]
-
-        # Define constants
-        R = FunctionSpace(mesh_seq[index], "R", 0)
-        dt = Function(R).assign(mesh_seq.time_partition.timesteps[index])
-        nu = Function(R).assign(0.0001)
-
-        # Setup variational problem
-        v = TestFunction(u.function_space())
-        F = (
-            inner((u - u_) / dt, v) * dx
-            + inner(dot(u, nabla_grad(u)), v) * dx
-            + nu * inner(grad(u), grad(v)) * dx
-        )
-        return {"u": F}
-
-    return form
 
 
 def get_initial_condition(mesh_seq):
@@ -61,8 +40,18 @@ def get_solver(mesh_seq):
     def solver(index):
         u, u_ = mesh_seq.fields["u"]
 
-        # Define form
-        F = mesh_seq.form(index)["u"]
+        # Define constants
+        R = FunctionSpace(mesh_seq[index], "R", 0)
+        dt = Function(R).assign(mesh_seq.time_partition.timesteps[index])
+        nu = Function(R).assign(0.0001)
+
+        # Setup variational problem
+        v = TestFunction(u.function_space())
+        F = (
+            inner((u - u_) / dt, v) * dx
+            + inner(dot(u, nabla_grad(u)), v) * dx
+            + nu * inner(grad(u), grad(v)) * dx
+        )
 
         # Time integrate from t_start to t_end
         t_start, t_end = mesh_seq.subintervals[index]
@@ -126,7 +115,6 @@ mesh_seq = AdjointMeshSeq(
     meshes,
     get_function_spaces=get_function_spaces,
     get_initial_condition=get_initial_condition,
-    get_form=get_form,
     get_solver=get_solver,
     get_qoi=get_qoi,
     qoi_type="time_integrated",

--- a/demos/point_discharge2d-hessian.py
+++ b/demos/point_discharge2d-hessian.py
@@ -36,10 +36,10 @@ def source(mesh):
     return 100.0 * exp(-((x - x0) ** 2 + (y - y0) ** 2) / r**2)
 
 
-def get_form(mesh_seq):
-    def form(index):
-        c = mesh_seq.fields["c"]
+def get_solver(mesh_seq):
+    def solver(index):
         function_space = mesh_seq.function_spaces["c"][index]
+        c = mesh_seq.fields["c"]
         h = CellSize(mesh_seq[index])
         S = source(mesh_seq[index])
 
@@ -63,18 +63,6 @@ def get_form(mesh_seq):
             + inner(D * grad(c), grad(psi)) * dx
             - S * psi * dx
         )
-        return {"c": F}
-
-    return form
-
-
-def get_solver(mesh_seq):
-    def solver(index):
-        function_space = mesh_seq.function_spaces["c"][index]
-        c = mesh_seq.fields["c"]
-
-        # Setup variational problem
-        F = mesh_seq.form(index)["c"]
         bc = DirichletBC(function_space, 0, 1)
 
         solve(F == 0, c, bcs=bc, ad_block_tag="c")
@@ -92,7 +80,6 @@ mesh_seq = MeshSeq(
     time_partition,
     mesh,
     get_function_spaces=get_function_spaces,
-    get_form=get_form,
     get_solver=get_solver,
 )
 

--- a/goalie/adjoint.py
+++ b/goalie/adjoint.py
@@ -85,7 +85,6 @@ class AdjointMeshSeq(MeshSeq):
             :meth:`~.MeshSeq.get_function_spaces`
         :kwarg get_initial_condition: a function as described in
             :meth:`~.MeshSeq.get_initial_condition`
-        :kwarg get_form: a function as described in :meth:`~.MeshSeq.get_form`
         :kwarg get_solver: a function as described in :meth:`~.MeshSeq.get_solver`
         :kwarg get_qoi: a function as described in :meth:`~.AdjointMeshSeq.get_qoi`
         """

--- a/goalie/go_mesh_seq.py
+++ b/goalie/go_mesh_seq.py
@@ -27,6 +27,28 @@ class GoalOrientedMeshSeq(AdjointMeshSeq):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.estimator_values = []
+        self._forms = None
+
+    def read_forms(self, forms_dictionary):
+        """
+        Read in the variational form corresponding to each prognostic field.
+
+        :arg forms_dictionary: dictionary where the keys are the field names and the
+            values are the UFL forms
+        :type forms_dictionary: :class:`dict`
+        """
+        self._forms = forms_dictionary
+
+    @property
+    def forms(self):
+        """
+        Get the variational form associated with each prognostic field.
+
+        :returns: dictionary where the keys are the field names and the values are the
+            UFL forms
+        :rtype: :class:`dict`
+        """
+        return self._forms
 
     @PETSc.Log.EventDecorator()
     def get_enriched_mesh_seq(self, enrichment_method="p", num_enrichments=1):
@@ -67,7 +89,6 @@ class GoalOrientedMeshSeq(AdjointMeshSeq):
             meshes,
             get_function_spaces=self._get_function_spaces,
             get_initial_condition=self._get_initial_condition,
-            get_form=self._get_form,
             get_solver=self._get_solver,
             get_qoi=self._get_qoi,
             qoi_type=self.qoi_type,
@@ -189,7 +210,7 @@ class GoalOrientedMeshSeq(AdjointMeshSeq):
 
             # Get forms for each equation in enriched space
             enriched_mesh_seq.fields = mapping
-            forms = enriched_mesh_seq.form(i)
+            forms = enriched_mesh_seq.forms
 
             # Loop over each timestep
             for j in range(self.time_partition.num_exports_per_subinterval[i] - 1):


### PR DESCRIPTION
Closes #223.

We only need the form when we do `GoalOrientedMeshSeq.indicate_errors`, so everything form-related was removed from `MeshSeq` and `AdjointMeshSeq`. Communicating the form from user code to `GoalOrientedMeshSeq` is now done with the `read_forms` method.