### PR TITLE
`adj_sol` is now a property

### DIFF
--- a/goalie/adjoint.py
+++ b/goalie/adjoint.py
@@ -194,12 +194,7 @@ class AdjointMeshSeq(MeshSeq):
         :returns: list of solve blocks
         :rtype: :class:`list` of :class:`pyadjoint.block.Block`\s
         """
-        tape = pyadjoint.get_working_tape()
-        if tape is None:
-            self.warning("Tape does not exist!")
-            return []
-
-        blocks = tape.get_blocks()
+        blocks = pyadjoint.get_working_tape().get_blocks()
         if len(blocks) == 0:
             self.warning("Tape has no blocks!")
             return blocks

--- a/goalie/adjoint.py
+++ b/goalie/adjoint.py
@@ -198,6 +198,7 @@ class AdjointMeshSeq(MeshSeq):
         if tape is None:
             self.warning("Tape does not exist!")
             return []
+        print(1)
 
         blocks = tape.get_blocks()
         if len(blocks) == 0:

--- a/goalie/adjoint.py
+++ b/goalie/adjoint.py
@@ -265,7 +265,7 @@ class AdjointMeshSeq(MeshSeq):
         # Default adjoint solution to zero, rather than None
         for block in solve_blocks:
             if block.adj_sol is None:
-                block.adj_sol = firedrake.Function(
+                block.adj_state = firedrake.Function(
                     self.function_spaces[field][subinterval], name=field
                 )
         return solve_blocks

--- a/goalie/adjoint.py
+++ b/goalie/adjoint.py
@@ -284,7 +284,7 @@ class AdjointMeshSeq(MeshSeq):
 
         # Loop through the solve block's outputs
         candidates = []
-        for out in solve_block._outputs:
+        for out in solve_block.get_outputs():
             # Look for Functions with matching function spaces
             if not isinstance(out.output, firedrake.Function):
                 continue
@@ -335,7 +335,7 @@ class AdjointMeshSeq(MeshSeq):
 
         # Loop through the solve block's dependencies
         candidates = []
-        for dep in solve_block._dependencies:
+        for dep in solve_block.get_dependencies():
             # Look for Functions with matching function spaces
             if not isinstance(dep.output, firedrake.Function):
                 continue

--- a/goalie/adjoint.py
+++ b/goalie/adjoint.py
@@ -179,7 +179,7 @@ class AdjointMeshSeq(MeshSeq):
         return checkpoints
 
     @PETSc.Log.EventDecorator()
-    def get_solve_blocks(self, field, subinterval, has_adj_sol=True):
+    def get_solve_blocks(self, field, subinterval):
         r"""
         Get all blocks of the tape corresponding to solve steps for prognostic solution
         field on a given subinterval.
@@ -188,9 +188,6 @@ class AdjointMeshSeq(MeshSeq):
         :type field: :class:`str`
         :arg subinterval: subinterval index
         :type subinterval: :class:`int`
-        :kwarg has_adj_sol: if ``True``, only blocks with ``adj_sol`` attributes will be
-            considered
-        :type has_adj_sol: :class:`bool`
         :returns: list of solve blocks
         :rtype: :class:`list` of :class:`pyadjoint.block.Block`\s
         """
@@ -247,22 +244,6 @@ class AdjointMeshSeq(MeshSeq):
                 f" field '{field}' on subinterval {subinterval}: {num_timesteps} vs."
                 f" {N}."
             )
-        if not has_adj_sol:
-            return solve_blocks
-
-        # Check that adjoint solutions exist
-        if all(block.adj_sol is None for block in solve_blocks):
-            self.warning(
-                "No block has an adjoint solution. Has the adjoint equation been"
-                " solved?"
-            )
-
-        # Default adjoint solution to zero, rather than None
-        for block in solve_blocks:
-            if block.adj_sol is None:
-                block.adj_state = firedrake.Function(
-                    self.function_spaces[field][subinterval], name=field
-                )
         return solve_blocks
 
     def _output(self, field, subinterval, solve_block):
@@ -525,7 +506,7 @@ class AdjointMeshSeq(MeshSeq):
 
             # Update adjoint solver kwargs
             for field in self.fields:
-                for block in self.get_solve_blocks(field, i, has_adj_sol=False):
+                for block in self.get_solve_blocks(field, i):
                     block.adj_kwargs.update(adj_solver_kwargs)
 
             # Solve adjoint problem
@@ -575,8 +556,7 @@ class AdjointMeshSeq(MeshSeq):
                         solutions.forward[i][j].assign(out.saved_output)
 
                     # Current adjoint solution is determined from the adj_sol attribute
-                    if block.adj_sol is not None:
-                        solutions.adjoint[i][j].assign(block.adj_sol)
+                    solutions.adjoint[i][j].assign(block.adj_sol)
 
                     # Lagged forward solution comes from dependencies
                     dep = self._dependency(field, i, block)
@@ -591,10 +571,9 @@ class AdjointMeshSeq(MeshSeq):
                     # adj_sol attribute of the next solve block
                     if not steady:
                         if (j + 1) * stride < num_solve_blocks:
-                            if solve_blocks[(j + 1) * stride].adj_sol is not None:
-                                solutions.adjoint_next[i][j].assign(
-                                    solve_blocks[(j + 1) * stride].adj_sol
-                                )
+                            solutions.adjoint_next[i][j].assign(
+                                solve_blocks[(j + 1) * stride].adj_sol
+                            )
                         elif (j + 1) * stride > num_solve_blocks:
                             raise IndexError(
                                 "Cannot extract solve block"
@@ -603,7 +582,7 @@ class AdjointMeshSeq(MeshSeq):
 
                 # The initial timestep of the current subinterval is the 'next' timestep
                 # after the final timestep of the previous subinterval
-                if i > 0 and solve_blocks[0].adj_sol is not None:
+                if i > 0:
                     self._transfer(
                         solve_blocks[0].adj_sol, solutions.adjoint_next[i - 1][-1]
                     )

--- a/goalie/adjoint.py
+++ b/goalie/adjoint.py
@@ -198,7 +198,6 @@ class AdjointMeshSeq(MeshSeq):
         if tape is None:
             self.warning("Tape does not exist!")
             return []
-        print(1)
 
         blocks = tape.get_blocks()
         if len(blocks) == 0:

--- a/test/adjoint/test_adjoint_mesh_seq.py
+++ b/test/adjoint/test_adjoint_mesh_seq.py
@@ -134,7 +134,7 @@ class TestBlockLogic(BaseClasses.RSpaceTestCase):
     def test_output_not_function(self, MockSolveBlock):
         solve_block = MockSolveBlock()
         block_variable = BlockVariable(1)
-        solve_block._outputs = [block_variable]
+        solve_block.get_outputs = lambda: [block_variable]
         with self.assertRaises(AttributeError) as cm:
             self.mesh_seq._output("field", 0, solve_block)
         msg = "Solve block for field 'field' on subinterval 0 has no outputs."
@@ -144,7 +144,7 @@ class TestBlockLogic(BaseClasses.RSpaceTestCase):
     def test_output_wrong_function_space(self, MockSolveBlock):
         solve_block = MockSolveBlock()
         block_variable = BlockVariable(Function(FunctionSpace(self.mesh, "CG", 1)))
-        solve_block._outputs = [block_variable]
+        solve_block.get_outputs = lambda: [block_variable]
         with self.assertRaises(AttributeError) as cm:
             self.mesh_seq._output("field", 0, solve_block)
         msg = "Solve block for field 'field' on subinterval 0 has no outputs."
@@ -155,7 +155,7 @@ class TestBlockLogic(BaseClasses.RSpaceTestCase):
         solve_block = MockSolveBlock()
         function_space = FunctionSpace(self.mesh, "R", 0)
         block_variable = BlockVariable(Function(function_space, name="field2"))
-        solve_block._outputs = [block_variable]
+        solve_block.get_outputs = lambda: [block_variable]
         with self.assertRaises(AttributeError) as cm:
             self.mesh_seq._output("field", 0, solve_block)
         msg = "Solve block for field 'field' on subinterval 0 has no outputs."
@@ -166,7 +166,7 @@ class TestBlockLogic(BaseClasses.RSpaceTestCase):
         solve_block = MockSolveBlock()
         function_space = FunctionSpace(self.mesh, "R", 0)
         block_variable = BlockVariable(Function(function_space, name="field"))
-        solve_block._outputs = [block_variable]
+        solve_block.get_outputs = lambda: [block_variable]
         self.assertIsNotNone(self.mesh_seq._output("field", 0, solve_block))
 
     @patch("firedrake.adjoint_utils.blocks.solving.GenericSolveBlock")
@@ -174,7 +174,7 @@ class TestBlockLogic(BaseClasses.RSpaceTestCase):
         solve_block = MockSolveBlock()
         function_space = FunctionSpace(self.mesh, "R", 0)
         block_variable = BlockVariable(Function(function_space, name="field"))
-        solve_block._outputs = [block_variable, block_variable]
+        solve_block.get_outputs = lambda: [block_variable, block_variable]
         with self.assertRaises(AttributeError) as cm:
             self.mesh_seq._output("field", 0, solve_block)
         msg = (
@@ -187,7 +187,7 @@ class TestBlockLogic(BaseClasses.RSpaceTestCase):
     def test_dependency_not_function(self, MockSolveBlock):
         solve_block = MockSolveBlock()
         block_variable = BlockVariable(1)
-        solve_block._dependencies = [block_variable]
+        solve_block.get_dependencies = lambda: [block_variable]
         with self.assertRaises(AttributeError) as cm:
             self.mesh_seq._dependency("field", 0, solve_block)
         msg = "Solve block for field 'field' on subinterval 0 has no dependencies."
@@ -197,7 +197,7 @@ class TestBlockLogic(BaseClasses.RSpaceTestCase):
     def test_dependency_wrong_function_space(self, MockSolveBlock):
         solve_block = MockSolveBlock()
         block_variable = BlockVariable(Function(FunctionSpace(self.mesh, "CG", 1)))
-        solve_block._dependencies = [block_variable]
+        solve_block.get_dependencies = lambda: [block_variable]
         with self.assertRaises(AttributeError) as cm:
             self.mesh_seq._dependency("field", 0, solve_block)
         msg = "Solve block for field 'field' on subinterval 0 has no dependencies."
@@ -208,7 +208,7 @@ class TestBlockLogic(BaseClasses.RSpaceTestCase):
         solve_block = MockSolveBlock()
         function_space = FunctionSpace(self.mesh, "R", 0)
         block_variable = BlockVariable(Function(function_space, name="field_new"))
-        solve_block._dependencies = [block_variable]
+        solve_block.get_dependencies = lambda: [block_variable]
         with self.assertRaises(AttributeError) as cm:
             self.mesh_seq._dependency("field", 0, solve_block)
         msg = "Solve block for field 'field' on subinterval 0 has no dependencies."
@@ -219,7 +219,7 @@ class TestBlockLogic(BaseClasses.RSpaceTestCase):
         solve_block = MockSolveBlock()
         function_space = FunctionSpace(self.mesh, "R", 0)
         block_variable = BlockVariable(Function(function_space, name="field_old"))
-        solve_block._dependencies = [block_variable]
+        solve_block.get_dependencies = lambda: [block_variable]
         self.assertIsNotNone(self.mesh_seq._dependency("field", 0, solve_block))
 
     @patch("firedrake.adjoint_utils.blocks.solving.GenericSolveBlock")
@@ -227,7 +227,7 @@ class TestBlockLogic(BaseClasses.RSpaceTestCase):
         solve_block = MockSolveBlock()
         function_space = FunctionSpace(self.mesh, "R", 0)
         block_variable = BlockVariable(Function(function_space, name="field_old"))
-        solve_block._dependencies = [block_variable, block_variable]
+        solve_block.get_dependencies = lambda: [block_variable, block_variable]
         with self.assertRaises(AttributeError) as cm:
             self.mesh_seq._dependency("field", 0, solve_block)
         msg = (

--- a/test/adjoint/test_adjoint_mesh_seq.py
+++ b/test/adjoint/test_adjoint_mesh_seq.py
@@ -248,27 +248,6 @@ class TestBlockLogic(BaseClasses.RSpaceTestCase):
         solve_block = MockSolveBlock()
         self.assertIsNone(mesh_seq._dependency("field", 0, solve_block))
 
-    def test_get_solve_blocks_adj_sol_none(self):
-        """
-        Default adjoint solution should be zero, rather than None.
-        """
-        time_interval = TimeInterval(1.0, 0.5, "field")
-        mesh_seq = AdjointMeshSeq(
-            time_interval,
-            self.mesh,
-            get_function_spaces=lambda mesh: {"field": FunctionSpace(mesh, "R", 0)},
-            qoi_type="end_time",
-        )
-        u = Function(mesh_seq.function_spaces["field"][0])
-        u0 = Function(u.function_space()).assign(u)
-        v = TestFunction(u.function_space())
-        F = u * v * ufl.dx - u0 * v * ufl.dx
-        for _ in range(2):
-            solve(F == 0, u, ad_block_tag="field")
-        solve_blocks = mesh_seq.get_solve_blocks("field", 0)
-        self.assertIsNotNone(solve_blocks[0].adj_sol)
-        self.assertEqual(solve_blocks[0].adj_sol.name(), "field")
-
 
 class TestGetSolveBlocks(BaseClasses.RSpaceTestCase):
     """

--- a/test/adjoint/test_adjoint_mesh_seq.py
+++ b/test/adjoint/test_adjoint_mesh_seq.py
@@ -24,14 +24,25 @@ from goalie.log import WARNING
 from goalie.time_partition import TimeInterval, TimePartition
 
 
-class TestBlockLogic(unittest.TestCase):
+class BaseClasses:
+    """
+    Base classes for unit tests.
+    """
+
+    class RSpaceTestCase(unittest.TestCase):
+        """
+        Unit test case using R-space.
+        """
+
+        @staticmethod
+        def get_function_spaces(mesh):
+            return {"field": FunctionSpace(mesh, "R", 0)}
+
+
+class TestBlockLogic(BaseClasses.RSpaceTestCase):
     """
     Unit tests for :meth:`MeshSeq._dependency` and :meth:`MeshSeq._output`.
     """
-
-    @staticmethod
-    def get_R_spaces(mesh):
-        return {"field": FunctionSpace(mesh, "R", 0)}
 
     def setUp(self):
         self.time_interval = TimeInterval(1.0, 0.5, "field")
@@ -39,7 +50,7 @@ class TestBlockLogic(unittest.TestCase):
         self.mesh_seq = AdjointMeshSeq(
             self.time_interval,
             self.mesh,
-            get_function_spaces=self.get_R_spaces,
+            get_function_spaces=self.get_function_spaces,
             qoi_type="end_time",
         )
 
@@ -155,7 +166,7 @@ class TestBlockLogic(unittest.TestCase):
         mesh_seq = AdjointMeshSeq(
             time_interval,
             self.mesh,
-            get_function_spaces=self.get_R_spaces,
+            get_function_spaces=self.get_function_spaces,
             qoi_type="end_time",
         )
         solve_block = MockSolveBlock()
@@ -184,14 +195,10 @@ class TestBlockLogic(unittest.TestCase):
         self.assertEqual(solve_blocks[0].adj_sol.name(), "field")
 
 
-class TestGetSolveBlocks(unittest.TestCase):
+class TestGetSolveBlocks(BaseClasses.RSpaceTestCase):
     """
     Unit tests for :meth:`get_solve_blocks`.
     """
-
-    @staticmethod
-    def get_function_spaces(mesh):
-        return {"field": FunctionSpace(mesh, "R", 0)}
 
     def setUp(self):
         time_interval = TimeInterval(1.0, [1.0], ["field"])
@@ -549,7 +556,7 @@ class TestGlobalEnrichment(TrivialGoalOrientedBaseClass):
         self.assertAlmostEqual(norm(source), norm(target))
 
 
-class GoalOrientedBaseClass(unittest.TestCase):
+class GoalOrientedBaseClass(BaseClasses.RSpaceTestCase):
     """
     Base class for tests with a complete :class:`GoalOrientedMeshSeq`.
     """
@@ -560,9 +567,6 @@ class GoalOrientedBaseClass(unittest.TestCase):
         self.meshes = [UnitSquareMesh(1, 1)]
 
     def go_mesh_seq(self, coeff_diff=0.0):
-        def get_function_spaces(mesh):
-            return {self.field: FunctionSpace(mesh, "R", 0)}
-
         def get_initial_condition(mesh_seq):
             return {self.field: Function(mesh_seq.function_spaces[self.field][0])}
 
@@ -598,7 +602,7 @@ class GoalOrientedBaseClass(unittest.TestCase):
             self.time_partition,
             self.meshes,
             get_initial_condition=get_initial_condition,
-            get_function_spaces=get_function_spaces,
+            get_function_spaces=self.get_function_spaces,
             get_solver=get_solver,
             get_qoi=get_qoi,
             qoi_type="end_time",

--- a/test/adjoint/test_adjoint_mesh_seq.py
+++ b/test/adjoint/test_adjoint_mesh_seq.py
@@ -250,8 +250,7 @@ class TestBlockLogic(BaseClasses.RSpaceTestCase):
 
     def test_get_solve_blocks_adj_sol_none(self):
         """
-        Covers the block of code with comment "Default adjoint solution to zero, rather
-        than None"
+        Default adjoint solution should be zero, rather than None.
         """
         time_interval = TimeInterval(1.0, 0.5, "field")
         mesh_seq = AdjointMeshSeq(

--- a/test/adjoint/test_adjoint_mesh_seq.py
+++ b/test/adjoint/test_adjoint_mesh_seq.py
@@ -30,8 +30,8 @@ class TestBlockLogic(unittest.TestCase):
     """
 
     @staticmethod
-    def get_p0_spaces(mesh):
-        return {"field": FunctionSpace(mesh, "DG", 0)}
+    def get_R_spaces(mesh):
+        return {"field": FunctionSpace(mesh, "R", 0)}
 
     def setUp(self):
         self.time_interval = TimeInterval(1.0, 0.5, "field")
@@ -39,7 +39,7 @@ class TestBlockLogic(unittest.TestCase):
         self.mesh_seq = AdjointMeshSeq(
             self.time_interval,
             self.mesh,
-            get_function_spaces=self.get_p0_spaces,
+            get_function_spaces=self.get_R_spaces,
             qoi_type="end_time",
         )
 
@@ -66,7 +66,7 @@ class TestBlockLogic(unittest.TestCase):
     @patch("firedrake.adjoint_utils.blocks.solving.GenericSolveBlock")
     def test_output_wrong_name(self, MockSolveBlock):
         solve_block = MockSolveBlock()
-        function_space = FunctionSpace(self.mesh, "DG", 0)
+        function_space = FunctionSpace(self.mesh, "R", 0)
         block_variable = BlockVariable(Function(function_space, name="field2"))
         solve_block._outputs = [block_variable]
         with self.assertRaises(AttributeError) as cm:
@@ -77,7 +77,7 @@ class TestBlockLogic(unittest.TestCase):
     @patch("firedrake.adjoint_utils.blocks.solving.GenericSolveBlock")
     def test_output_valid(self, MockSolveBlock):
         solve_block = MockSolveBlock()
-        function_space = FunctionSpace(self.mesh, "DG", 0)
+        function_space = FunctionSpace(self.mesh, "R", 0)
         block_variable = BlockVariable(Function(function_space, name="field"))
         solve_block._outputs = [block_variable]
         self.assertIsNotNone(self.mesh_seq._output("field", 0, solve_block))
@@ -85,7 +85,7 @@ class TestBlockLogic(unittest.TestCase):
     @patch("firedrake.adjoint_utils.blocks.solving.GenericSolveBlock")
     def test_output_multiple_valid_error(self, MockSolveBlock):
         solve_block = MockSolveBlock()
-        function_space = FunctionSpace(self.mesh, "DG", 0)
+        function_space = FunctionSpace(self.mesh, "R", 0)
         block_variable = BlockVariable(Function(function_space, name="field"))
         solve_block._outputs = [block_variable, block_variable]
         with self.assertRaises(AttributeError) as cm:
@@ -119,7 +119,7 @@ class TestBlockLogic(unittest.TestCase):
     @patch("firedrake.adjoint_utils.blocks.solving.GenericSolveBlock")
     def test_dependency_wrong_name(self, MockSolveBlock):
         solve_block = MockSolveBlock()
-        function_space = FunctionSpace(self.mesh, "DG", 0)
+        function_space = FunctionSpace(self.mesh, "R", 0)
         block_variable = BlockVariable(Function(function_space, name="field_new"))
         solve_block._dependencies = [block_variable]
         with self.assertRaises(AttributeError) as cm:
@@ -130,7 +130,7 @@ class TestBlockLogic(unittest.TestCase):
     @patch("firedrake.adjoint_utils.blocks.solving.GenericSolveBlock")
     def test_dependency_valid(self, MockSolveBlock):
         solve_block = MockSolveBlock()
-        function_space = FunctionSpace(self.mesh, "DG", 0)
+        function_space = FunctionSpace(self.mesh, "R", 0)
         block_variable = BlockVariable(Function(function_space, name="field_old"))
         solve_block._dependencies = [block_variable]
         self.assertIsNotNone(self.mesh_seq._dependency("field", 0, solve_block))
@@ -138,7 +138,7 @@ class TestBlockLogic(unittest.TestCase):
     @patch("firedrake.adjoint_utils.blocks.solving.GenericSolveBlock")
     def test_dependency_multiple_valid_error(self, MockSolveBlock):
         solve_block = MockSolveBlock()
-        function_space = FunctionSpace(self.mesh, "DG", 0)
+        function_space = FunctionSpace(self.mesh, "R", 0)
         block_variable = BlockVariable(Function(function_space, name="field_old"))
         solve_block._dependencies = [block_variable, block_variable]
         with self.assertRaises(AttributeError) as cm:
@@ -155,13 +155,17 @@ class TestBlockLogic(unittest.TestCase):
         mesh_seq = AdjointMeshSeq(
             time_interval,
             self.mesh,
-            get_function_spaces=self.get_p0_spaces,
+            get_function_spaces=self.get_R_spaces,
             qoi_type="end_time",
         )
         solve_block = MockSolveBlock()
         self.assertIsNone(mesh_seq._dependency("field", 0, solve_block))
 
-    def test_dependency_unsteady(self):
+    def test_get_solve_blocks_adj_sol_none(self):
+        """
+        Covers the block of code with comment "Default adjoint solution to zero, rather
+        than None"
+        """
         time_interval = TimeInterval(1.0, 0.5, "field")
         mesh_seq = AdjointMeshSeq(
             time_interval,


### PR DESCRIPTION
It's no longer valid for us to set `SolveVarFormBlock.adj_sol` because it's now a property that returns the `adj_state` attribute. It appears the corresponding section of code "Default adjoint solution to zero, rather than None" wasn't covered by tests, so I added a test that covers it. I also dropped the redundant section of code that checks whether the tape object exists (it always does).

While writing the unit test, I refactored the surrounding tests somewhat to improve consistency and make use of class inheritance to avoid duplication.