### PR TITLE
Meshes are now iterable

### DIFF
--- a/goalie/error_estimation.py
+++ b/goalie/error_estimation.py
@@ -107,7 +107,7 @@ def get_dwr_indicator(F, adjoint_error, test_space=None):
     elif isinstance(test_space, WithGeometry):
         if len(adjoint_error.keys()) != 1:
             raise ValueError("Inconsistent input for 'adjoint_error' and 'test_space'.")
-        test_space = {key: test_space for key in adjoint_error}
+        test_space = dict.fromkeys(adjoint_error, test_space)
     elif not isinstance(test_space, dict):
         raise TypeError(
             "Expected 'test_space' to be a FunctionSpace or dict, not"

--- a/goalie/function_data.py
+++ b/goalie/function_data.py
@@ -388,9 +388,7 @@ class IndicatorData(FunctionData):
             in time
         :arg meshes: the list of meshes used to discretise the problem in space
         """
-        self._label_dict = {
-            time_dep: ("error_indicator",) for time_dep in ("steady", "unsteady")
-        }
+        self._label_dict = dict.fromkeys(("steady", "unsteady"), ("error_indicator",))
         super().__init__(
             time_partition,
             {

--- a/goalie/mesh_seq.py
+++ b/goalie/mesh_seq.py
@@ -166,7 +166,7 @@ class MeshSeq:
             :class:`firedrake.MeshGeometry`
         """
         # TODO #122: Refactor to use the set method
-        if not isinstance(meshes, Iterable):
+        if not isinstance(meshes, list):
             meshes = [Mesh(meshes) for subinterval in self.subintervals]
         self.meshes = meshes
         dim = np.array([mesh.topological_dimension() for mesh in meshes])

--- a/goalie/mesh_seq.py
+++ b/goalie/mesh_seq.py
@@ -49,7 +49,7 @@ class MeshSeq:
             take various types
         """
         self.time_partition = time_partition
-        self.fields = {field_name: None for field_name in time_partition.field_names}
+        self.fields = dict.fromkeys(time_partition.field_names)
         self.field_types = dict(zip(self.fields, time_partition.field_types))
         self.subintervals = time_partition.subintervals
         self.num_subintervals = time_partition.num_subintervals


### PR DESCRIPTION
The CI in #291 fails since meshes are now iterable (not our change). So in this PR I just changed `isinstance(meshes, Iterable)` to `isinstance(meshes, list)`.

This will anyway get refactored in #239 to always require a list of meshes, since
```
if not isinstance(meshes, Iterable):
    meshes = [Mesh(meshes) for subinterval in self.subintervals]
```
will not be possible to do since `MeshSeq` will be completely separated from `TimePartition`s, so there won't be a `self.subintervals` attribute anymore.