### PR TITLE
Update $p$-refinement after moving to `Field` approach

### DIFF
--- a/goalie/adjoint.py
+++ b/goalie/adjoint.py
@@ -542,7 +542,7 @@ class AdjointMeshSeq(MeshSeq):
                     )
 
             # Loop over prognostic variables
-            for fieldname, fs in self.function_spaces.items():
+            for fieldname, field in self.field_metadata.items():
                 # Get solve blocks
                 solve_blocks = self.get_solve_blocks(fieldname, i)
                 num_solve_blocks = len(solve_blocks)

--- a/goalie/adjoint.py
+++ b/goalie/adjoint.py
@@ -551,11 +551,12 @@ class AdjointMeshSeq(MeshSeq):
                         "Looks like no solves were written to tape!"
                         " Does the solution depend on the initial condition?"
                     )
-                if fs[0].ufl_element() != solve_blocks[0].function_space.ufl_element():
+                finite_element = field.finite_element
+                sb_element0 = solve_blocks[0].function_space.ufl_element()
+                if finite_element != sb_element0:
                     raise ValueError(
                         f"Solve block list for field '{fieldname}' contains mismatching"
-                        f" finite elements: ({fs[0].ufl_element()} vs. "
-                        f" {solve_blocks[0].function_space.ufl_element()})"
+                        f" finite elements: ({finite_element} vs. {sb_element0})"
                     )
 
                 # Detect whether we have a steady problem

--- a/goalie/go_mesh_seq.py
+++ b/goalie/go_mesh_seq.py
@@ -13,9 +13,11 @@ from firedrake.petsc import PETSc
 
 from .adjoint import AdjointMeshSeq
 from .error_estimation import get_dwr_indicator
+from .field import Field
 from .function_data import IndicatorData
 from .log import pyrint
 from .options import GoalOrientedAdaptParameters
+from .time_partition import TimePartition
 
 __all__ = ["GoalOrientedMeshSeq"]
 
@@ -149,9 +151,32 @@ class GoalOrientedMeshSeq(AdjointMeshSeq):
         else:
             meshes = self.meshes
 
+        # Apply p-refinement
+        tp = self.time_partition
+        if enrichment_method == "p":
+            field_metadata = {}
+            for fieldname, field in self.field_metadata.items():
+                element = field.finite_element
+                element = element.reconstruct(degree=element.degree() + num_enrichments)
+                field_metadata[fieldname] = Field(
+                    fieldname,
+                    finite_element=element,
+                    solved_for=field.solved_for,
+                    unsteady=field.unsteady,
+                )
+            tp = TimePartition(
+                tp.end_time,
+                tp.num_subintervals,
+                tp.timesteps,
+                field_metadata,
+                num_timesteps_per_export=tp.num_timesteps_per_export,
+                start_time=tp.start_time,
+                subintervals=tp.subintervals,
+            )
+
         # Construct object to hold enriched spaces
         enriched_mesh_seq = type(self)(
-            self.time_partition,
+            tp,
             meshes,
             get_initial_condition=self._get_initial_condition,
             get_solver=self._get_solver,
@@ -159,18 +184,6 @@ class GoalOrientedMeshSeq(AdjointMeshSeq):
             qoi_type=self.qoi_type,
         )
         enriched_mesh_seq._update_function_spaces()
-
-        # Apply p-refinement
-        if enrichment_method == "p":
-            for label, fs in enriched_mesh_seq.function_spaces.items():
-                for n, _space in enumerate(fs):
-                    element = _space.ufl_element()
-                    element = element.reconstruct(
-                        degree=element.degree() + num_enrichments
-                    )
-                    enriched_mesh_seq._fs[label][n] = FunctionSpace(
-                        enriched_mesh_seq.meshes[n], element
-                    )
 
         return enriched_mesh_seq
 

--- a/test/adjoint/test_adjoint_mesh_seq.py
+++ b/test/adjoint/test_adjoint_mesh_seq.py
@@ -65,14 +65,18 @@ class BaseClasses:
                 parameters=parameters,
             )
 
-    class GoalOrientedBaseClass(RSpaceTestCase):
+    class GoalOrientedBaseClass(unittest.TestCase):
         """
         Base class for tests with a complete :class:`GoalOrientedMeshSeq`.
         """
 
+        def setUp(self):
+            mesh = UnitSquareMesh(1, 1)
+            self.meshes = [mesh]
+            self.field = Field("field", mesh=mesh, family="Real", degree=0)
+
         def go_mesh_seq(self, coeff_diff=0.0):
             self.time_partition = TimePartition(1.0, 1, 0.5, [self.field])
-            self.meshes = [UnitSquareMesh(1, 1)]
 
             def get_initial_condition(mesh_seq):
                 return {


### PR DESCRIPTION
I forgot to open this PR, which merges into #296. It updates the $p$-refinement approach now that we've moved to the `Field` approach. Personally, I think it's much neater now.

The reason the `goalie/adjoint.py` check is in this PR is that it fails for some tests unless the $p$-refinement is updated as in this PR.