### PR TITLE
Introduce `get_element` and `get_function_space` methods to `Field` class

### DIFF
--- a/demos/burgers-goal_oriented.py
+++ b/demos/burgers-goal_oriented.py
@@ -21,7 +21,7 @@ from goalie_adjoint import *
 
 n = 32
 meshes = [UnitSquareMesh(n, n), UnitSquareMesh(n, n)]
-fields = [Field("u", family="Lagrange", mesh=meshes[0], degree=2, vector=True)]
+fields = [Field("u", family="Lagrange", degree=2, vector=True)]
 
 
 def get_initial_condition(mesh_seq):

--- a/demos/burgers-hessian.py
+++ b/demos/burgers-hessian.py
@@ -23,7 +23,7 @@ from goalie import *
 
 n = 32
 meshes = [UnitSquareMesh(n, n), UnitSquareMesh(n, n)]
-fields = [Field("u", family="Lagrange", mesh=meshes[0], degree=2, vector=True)]
+fields = [Field("u", family="Lagrange", degree=2, vector=True)]
 
 
 def get_solver(mesh_seq):

--- a/demos/burgers.py
+++ b/demos/burgers.py
@@ -40,7 +40,7 @@ mesh = UnitSquareMesh(n, n)
 # this case, we use a :math:`\mathbb{P}2` space so specify `family="Lagrange"` and
 # `degree=2`.Since Burgers is a vector equation, we need to specify `vector=True`. ::
 
-fields = [Field("u", family="Lagrange", mesh=mesh, degree=2, vector=True)]
+fields = [Field("u", family="Lagrange", degree=2, vector=True)]
 
 # The solution :class:`Function`\s are automatically built on the function spaces given
 # by the :func:`get_function_spaces` function and are accessed via the

--- a/demos/burgers1.py
+++ b/demos/burgers1.py
@@ -21,7 +21,7 @@ from goalie_adjoint import *
 
 n = 32
 mesh = UnitSquareMesh(n, n)
-fields = [Field("u", family="Lagrange", mesh=mesh, degree=2, vector=True)]
+fields = [Field("u", family="Lagrange", degree=2, vector=True)]
 
 
 def get_solver(mesh_seq):

--- a/demos/burgers2.py
+++ b/demos/burgers2.py
@@ -20,7 +20,7 @@ set_log_level(DEBUG)
 
 n = 32
 mesh = UnitSquareMesh(n, n, diagonal="left")
-fields = [Field("u", family="Lagrange", mesh=mesh, degree=2, vector=True)]
+fields = [Field("u", family="Lagrange", degree=2, vector=True)]
 
 
 def get_solver(mesh_seq):

--- a/demos/burgers_ee.py
+++ b/demos/burgers_ee.py
@@ -46,7 +46,7 @@ set_log_level(DEBUG)
 
 n = 32
 meshes = [UnitSquareMesh(n, n), UnitSquareMesh(n, n)]
-fields = [Field("u", family="Lagrange", mesh=meshes[0], degree=2, vector=True)]
+fields = [Field("u", family="Lagrange", degree=2, vector=True)]
 
 
 def get_solver(mesh_seq):

--- a/demos/burgers_oo.py
+++ b/demos/burgers_oo.py
@@ -96,7 +96,7 @@ class BurgersMeshSeq(GoalOrientedMeshSeq):
 
 n = 32
 meshes = [UnitSquareMesh(n, n), UnitSquareMesh(n, n)]
-fields = [Field("u", family="Lagrange", mesh=meshes[0], degree=2, vector=True)]
+fields = [Field("u", family="Lagrange", degree=2, vector=True)]
 
 end_time = 0.5
 dt = 1 / n

--- a/demos/burgers_time_integrated.py
+++ b/demos/burgers_time_integrated.py
@@ -16,7 +16,7 @@ from goalie_adjoint import *
 
 n = 32
 mesh = UnitSquareMesh(n, n)
-fields = [Field("u", family="Lagrange", mesh=mesh, degree=2, vector=True)]
+fields = [Field("u", family="Lagrange", degree=2, vector=True)]
 
 
 def get_initial_condition(mesh_seq):

--- a/demos/mesh_seq.py
+++ b/demos/mesh_seq.py
@@ -22,7 +22,7 @@ set_log_level(DEBUG)
 # Consider the final subinterval from the previous demo. ::
 
 end_time = 1.0
-fields = [Field("solution")]
+fields = [Field("solution", family="Real")]
 dt = [0.125, 0.0625]
 subintervals = [(0.0, 0.75), (0.75, 1.0)]
 time_partition = TimePartition(

--- a/demos/ode.py
+++ b/demos/ode.py
@@ -54,7 +54,7 @@ from goalie import *
 # :math:`R`-space. ::
 
 mesh = VertexOnlyMesh(UnitIntervalMesh(1), [[0.5]])
-fields = [Field("u", mesh=mesh, family="Real", degree=0)]
+fields = [Field("u", family="Real", degree=0)]
 
 # Next, create a simple :class:`~.TimeInterval` object to hold information related to
 # the time discretisation. This is a simplified version of :class:`~.TimePartition`,

--- a/demos/point_discharge2d-goal_oriented.py
+++ b/demos/point_discharge2d-goal_oriented.py
@@ -20,7 +20,7 @@ from matplotlib import ticker
 from goalie_adjoint import *
 
 mesh = RectangleMesh(50, 10, 50, 10)
-fields = [Field("c", mesh=mesh, family="Lagrange", degree=1, unsteady=False)]
+fields = [Field("c", family="Lagrange", degree=1, unsteady=False)]
 
 
 def source(mesh):

--- a/demos/point_discharge2d-hessian.py
+++ b/demos/point_discharge2d-hessian.py
@@ -25,7 +25,7 @@ from goalie import *
 # initial mesh. ::
 
 mesh = RectangleMesh(50, 10, 50, 10)
-fields = [Field("c", mesh=mesh, family="Lagrange", degree=1, unsteady=False)]
+fields = [Field("c", family="Lagrange", degree=1, unsteady=False)]
 
 
 def source(mesh):

--- a/demos/point_discharge2d.py
+++ b/demos/point_discharge2d.py
@@ -33,7 +33,7 @@ from goalie_adjoint import *
 # We solve the advection-diffusion problem in :math:`\mathbb P1` space. ::
 
 mesh = RectangleMesh(200, 40, 50, 10)
-fields = [Field("c", mesh=mesh, family="Lagrange", degree=1, unsteady=False)]
+fields = [Field("c", family="Lagrange", degree=1, unsteady=False)]
 
 # Point sources are difficult to represent in numerical models. Here we
 # follow :cite:`Wallwork:2022` in using a Gaussian approximation. Let

--- a/demos/solid_body_rotation.py
+++ b/demos/solid_body_rotation.py
@@ -48,7 +48,7 @@ coords = mesh.coordinates.copy(deepcopy=True)
 coords.interpolate(coords - as_vector([0.5, 0.5]))
 mesh = Mesh(coords)
 
-fields = [Field("c", mesh=mesh, family="Lagrange", degree=1)]
+fields = [Field("c", family="Lagrange", degree=1)]
 
 
 # Next, let's define the initial condition, to get a

--- a/demos/time_partition.py
+++ b/demos/time_partition.py
@@ -51,10 +51,10 @@ from goalie import *
 end_time = 1.0
 num_subintervals = 1
 dt = 0.125
-fields = [Field("solution")]
+fields = [Field("solution", family="Real")]
 
 # The :class:`~.Field` class accepts keyword arguments to customise more than just the
-# name, but we use the defaults here for simplicity.
+# name and finite element family, which we demonstrate in later demos.
 #
 # With these definitions, we should get
 # one subinterval of :math:`(0,1]` containing

--- a/goalie/adjoint.py
+++ b/goalie/adjoint.py
@@ -551,7 +551,7 @@ class AdjointMeshSeq(MeshSeq):
                         "Looks like no solves were written to tape!"
                         " Does the solution depend on the initial condition?"
                     )
-                finite_element = field.finite_element
+                finite_element = field.get_element(self.meshes[i])
                 sb_element0 = solve_blocks[0].function_space.ufl_element()
                 if finite_element != sb_element0:
                     raise ValueError(

--- a/goalie/field.py
+++ b/goalie/field.py
@@ -3,6 +3,7 @@ from finat.ufl import (
     VectorElement,
 )
 from firedrake.functionspace import FunctionSpace, make_scalar_element
+from firedrake.utility_meshes import UnitIntervalMesh
 
 
 class Field:
@@ -76,8 +77,14 @@ class Field:
         return f"Field({self.name})"
 
     def __repr__(self):
+        if self.finite_element is not None:
+            element_str = self.finite_element
+        else:
+            _element = self.get_element(UnitIntervalMesh(1))
+            element_str = str(_element).replace("interval", "unknown cell type")
+
         return (
-            f"Field('{self.name}', {self.finite_element}, solved_for={self.solved_for},"
+            f"Field('{self.name}', {element_str}, solved_for={self.solved_for},"
             f" unsteady={self.unsteady})"
         )
 

--- a/goalie/field.py
+++ b/goalie/field.py
@@ -31,7 +31,7 @@ class Field:
         
         If the `finite_element` keyword argument is specified, these other arguments are
         ignored. If neither are specified, the default finite element is a scalar Real
-        space on an interval.
+        space.
 
         To account for mixed and tensor elements, please fully specify the element and
         pass it via the `finite_element` keyword argument.

--- a/goalie/field.py
+++ b/goalie/field.py
@@ -102,7 +102,7 @@ class Field:
         Given a mesh, return the finite element associated with the field.
 
         :arg mesh: The mesh to determine the cell from.
-        :type mesh: :class:`~.Mesh`
+        :type mesh: :class:`~.firedrake.mesh.MeshGeometry`
         :return: The finite element associated with the field.
         :rtype: An appropriate subclass of :class:`~.FiniteElementBase`
         """
@@ -133,7 +133,7 @@ class Field:
         Given a mesh, return the function space associated with the field.
 
         :arg mesh: The mesh to determine the cell from.
-        :type mesh: :class:`~.Mesh`
+        :type mesh: :class:`~.firedrake.mesh.MeshGeometry`
         :return: The function space associated with the field.
         :rtype: :class:`~firedrake.functionspaceimpl.FunctionSpace`
         """

--- a/goalie/field.py
+++ b/goalie/field.py
@@ -27,10 +27,11 @@ class Field:
         The finite element for the Field should be set either using the `finite_element`
         keyword argument or a combination of the `mesh`, `family`, `degree`, `vfamily`,
         `vdegree`, and/or `variant` keyword arguments. For details on these arguments,
-        see :class:`firedrake.functionspace.FunctionSpace`.
-
-        If neither are specified, the default finite element is a scalar Real space on
-        and interval.
+        see :class:`firedrake.functionspace.FunctionSpace`. 
+        
+        If the `finite_element` keyword argument is specified, these other arguments are
+        ignored. If neither are specified, the default finite element is a scalar Real
+        space on an interval.
 
         To account for mixed and tensor elements, please fully specify the element and
         pass it via the `finite_element` keyword argument.
@@ -100,7 +101,7 @@ class Field:
         """
         Given a mesh, return the finite element associated with the field.
 
-        :arg mesh: The mesh to use for the finite element.
+        :arg mesh: The mesh to determine the cell from.
         :type mesh: :class:`~.Mesh`
         :return: The finite element associated with the field.
         :rtype: An appropriate subclass of :class:`~.FiniteElementBase`
@@ -131,7 +132,7 @@ class Field:
         """
         Given a mesh, return the function space associated with the field.
 
-        :arg mesh: The mesh to use for the function space.
+        :arg mesh: The mesh to determine the cell from.
         :type mesh: :class:`~.Mesh`
         :return: The function space associated with the field.
         :rtype: :class:`~firedrake.functionspaceimpl.FunctionSpace`

--- a/goalie/go_mesh_seq.py
+++ b/goalie/go_mesh_seq.py
@@ -156,7 +156,7 @@ class GoalOrientedMeshSeq(AdjointMeshSeq):
         if enrichment_method == "p":
             field_metadata = {}
             for fieldname, field in self.field_metadata.items():
-                element = field.finite_element
+                element = field.get_element(meshes[0])
                 element = element.reconstruct(degree=element.degree() + num_enrichments)
                 field_metadata[fieldname] = Field(
                     fieldname,

--- a/goalie/mesh_seq.py
+++ b/goalie/mesh_seq.py
@@ -5,7 +5,6 @@ Sequences of meshes corresponding to a :class:`~.TimePartition`.
 from collections.abc import Iterable
 
 import firedrake
-import firedrake.functionspace as ffs
 import numpy as np
 from animate.interpolation import transfer
 from animate.quality import QualityMeasure
@@ -255,8 +254,7 @@ class MeshSeq:
         """
         function_spaces = {}
         for fieldname, field in self.field_metadata.items():
-            assert field.finite_element.cell == mesh.coordinates.ufl_element().cell
-            function_spaces[fieldname] = ffs.FunctionSpace(mesh, field.finite_element)
+            function_spaces[fieldname] = field.get_function_space(mesh)
         return function_spaces
 
     def get_initial_condition(self):

--- a/test/adjoint/test_adjoint.py
+++ b/test/adjoint/test_adjoint.py
@@ -34,7 +34,7 @@ class TestAdjointMeshSeqGeneric(unittest.TestCase):
     """
 
     def setUp(self):
-        self.time_interval = TimeInterval(1.0, [0.5], Field("field"))
+        self.time_interval = TimeInterval(1.0, [0.5], Field("field", family="Real"))
         self.meshes = [UnitTriangleMesh()]
 
     def test_qoi_type_error(self):

--- a/test/adjoint/test_adjoint_mesh_seq.py
+++ b/test/adjoint/test_adjoint_mesh_seq.py
@@ -39,7 +39,7 @@ class BaseClasses:
         def setUp(self):
             mesh = UnitSquareMesh(1, 1)
             self.meshes = [mesh]
-            self.field = Field("field", mesh=mesh, family="Real", degree=0)
+            self.field = Field("field", family="Real", degree=0)
 
     class TrivialGoalOrientedBaseClass(unittest.TestCase):
         """
@@ -73,7 +73,7 @@ class BaseClasses:
         def setUp(self):
             mesh = UnitSquareMesh(1, 1)
             self.meshes = [mesh]
-            self.field = Field("field", mesh=mesh, family="Real", degree=0)
+            self.field = Field("field", family="Real", degree=0)
 
         def go_mesh_seq(self, coeff_diff=0.0):
             self.time_partition = TimePartition(1.0, 1, 0.5, [self.field])

--- a/test/adjoint/test_adjoint_mesh_seq.py
+++ b/test/adjoint/test_adjoint_mesh_seq.py
@@ -250,7 +250,8 @@ class TestBlockLogic(BaseClasses.RSpaceTestCase):
 
     @patch("firedrake.adjoint_utils.blocks.solving.GenericSolveBlock")
     def test_dependency_steady(self, MockSolveBlock):
-        self.time_interval = TimeInterval(1.0, 0.5, Field("field", unsteady=False))
+        field = Field("field", family="Real", unsteady=False)
+        self.time_interval = TimeInterval(1.0, 0.5, field)
         mesh_seq = AdjointMeshSeq(
             self.time_interval,
             self.mesh,
@@ -431,8 +432,9 @@ class TestGlobalEnrichment(BaseClasses.TrivialGoalOrientedBaseClass):
         end_time = 1.0
         num_subintervals = 2
         dt = end_time / num_subintervals
+        field = Field("field", family="Real")
         mesh_seq = GoalOrientedMeshSeq(
-            TimePartition(end_time, num_subintervals, dt, Field("field")),
+            TimePartition(end_time, num_subintervals, dt, field),
             [UnitTriangleMesh()] * num_subintervals,
             get_qoi=self.constant_qoi,
             qoi_type="end_time",

--- a/test/adjoint/test_gradient.py
+++ b/test/adjoint/test_gradient.py
@@ -25,8 +25,9 @@ class TestExceptions(unittest.TestCase):
     """
 
     def test_attribute_error(self):
+        field = Field("field", family="Real", degree=0, unsteady=False)
         mesh_seq = AdjointMeshSeq(
-            TimeInterval(1.0, 1.0, Field("field", unsteady=False)),
+            TimeInterval(1.0, 1.0, field),
             UnitIntervalMesh(1),
             qoi_type="steady",
         )
@@ -149,9 +150,8 @@ class TestGradientComputation(unittest.TestCase):
     """
 
     def time_partition(self, num_subintervals, dt, unsteady=True):
-        return TimePartition(
-            1.0, num_subintervals, dt, Field("field", unsteady=unsteady)
-        )
+        field = Field("field", family="Real", degree=0, unsteady=unsteady)
+        return TimePartition(1.0, num_subintervals, dt, field)
 
     @parameterized.expand(
         [

--- a/test/adjoint/test_utils.py
+++ b/test/adjoint/test_utils.py
@@ -18,7 +18,7 @@ class TestAdjointUtils(unittest.TestCase):
     """
 
     def setUp(self):
-        self.time_interval = TimeInterval(1.0, [0.5], Field("field"))
+        self.time_interval = TimeInterval(1.0, [0.5], Field("field", family="Real"))
         self.mesh = UnitSquareMesh(1, 1)
 
     def mesh_seq(self, qoi_type="end_time"):
@@ -101,7 +101,7 @@ class TestAdjointUtils(unittest.TestCase):
         assert str(cm.exception) == msg
 
     def test_annotate_qoi_steady(self):
-        time_interval = TimeInterval(1.0, [1.0], Field("field"))
+        time_interval = TimeInterval(1.0, [1.0], Field("field", family="Real"))
         with self.assertRaises(ValueError) as cm:
             AdjointMeshSeq(time_interval, [self.mesh], qoi_type="end_time")
         msg = "Time partition is steady but the QoI type is set to 'end_time'."

--- a/test/test_error_estimation.py
+++ b/test/test_error_estimation.py
@@ -25,7 +25,7 @@ class ErrorEstimationTestCase(unittest.TestCase):
 
     def setUp(self):
         self.mesh = UnitSquareMesh(1, 1)
-        self.field = Field("field", mesh=self.mesh, family="Real", degree=0)
+        self.field = Field("field", family="Real", degree=0)
         self.fs = FunctionSpace(self.mesh, "CG", 1)
         self.trial = TrialFunction(self.fs)
         self.test = TestFunction(self.fs)
@@ -79,7 +79,7 @@ class TestIndicators2Estimator(ErrorEstimationTestCase):
 
     def test_time_partition_wrong_field_error(self):
         time_partition1 = TimeInstant(self.field)
-        field2 = Field("field2", mesh=self.mesh, family="Real", degree=0)
+        field2 = Field("field2", family="Real", degree=0)
         time_partition2 = TimeInstant(field2)
         mesh_seq = self.mesh_seq(time_partition=time_partition1)
         mesh_seq._indicators = IndicatorData(time_partition2, mesh_seq.meshes)
@@ -138,7 +138,7 @@ class TestIndicators2Estimator(ErrorEstimationTestCase):
         )  # 0.5 * (0.5 + 0.5) + 0.25 * 2 * (0.5 + 0.5)
 
     def test_time_instant_multiple_fields(self):
-        field2 = Field("field2", mesh=self.mesh, family="Real", degree=0)
+        field2 = Field("field2", family="Real", degree=0)
         mesh_seq = self.mesh_seq(
             time_partition=TimeInstant([self.field, field2], time=1.0)
         )

--- a/test/test_field.py
+++ b/test/test_field.py
@@ -92,20 +92,12 @@ class TestGetElement(unittest.TestCase):
             field.get_element(mesh1d())
 
     def test_field_alternative_real(self):
-        field = Field(
-            name="field",
-            family="Real",
-            degree=0,
-        )
+        field = Field(name="field", family="Real", degree=0)
         finite_element = field.get_element(mesh1d())
         self.assertEqual(finite_element, real_element())
 
     def test_field_alternative_p1(self):
-        field = Field(
-            name="field",
-            family="Lagrange",
-            degree=1,
-        )
+        field = Field(name="field", family="Lagrange", degree=1)
         finite_element = field.get_element(mesh2d())
         self.assertEqual(finite_element, p1_element())
 

--- a/test/test_field.py
+++ b/test/test_field.py
@@ -52,6 +52,11 @@ class TestExceptions(unittest.TestCase):
         )
         self.assertEqual(str(cm.exception), msg)
 
+    def test_insufficient_arguments(self):
+        with self.assertRaises(ValueError) as cm:
+            Field("field")
+        msg = ("Either the finite_element or family must be specified.")
+        self.assertEqual(str(cm.exception), msg)
 
 class TestInit(unittest.TestCase):
     """Test initialisation of Field class."""

--- a/test/test_field.py
+++ b/test/test_field.py
@@ -32,21 +32,9 @@ class TestExceptions(unittest.TestCase):
     Firedrake.
     """
 
-    def test_make_scalar_element_error1(self):
-        with self.assertRaises(AttributeError):
-            Field("field", mesh="mesh", family="Real")
-
-    def test_make_scalar_element_error2(self):
-        with self.assertRaises(ValueError):
-            Field("field", mesh=mesh1d(), family="family")
-
-    def test_make_scalar_element_error3(self):
-        with self.assertRaises(ValueError):
-            Field("field", mesh=mesh1d(), family="Real", degree=-1)
-
     def test_unexpected_kwarg_error(self):
         with self.assertRaises(ValueError) as cm:
-            Field("field", mesh=mesh1d(), family="Real", degree=0, kwarg="blah")
+            Field("field", family="Real", degree=0, kwarg="blah")
         self.assertEqual(str(cm.exception), "Unexpected keyword argument 'kwarg'.")
 
     def test_element_and_rank_error(self):
@@ -85,23 +73,44 @@ class TestInit(unittest.TestCase):
         self.assertFalse(field.solved_for)
         self.assertFalse(field.unsteady)
 
+class TestGetElement(unittest.TestCase):
+    """Test `get_element` method of Field class."""
+
+    def test_make_scalar_element_error1(self):
+        # AttributeError: 'str' object has no attribute 'topology'
+        field = Field("field", family="Real")
+        with self.assertRaises(AttributeError):
+            field.get_element("mesh")
+
+    def test_make_scalar_element_error2(self):
+        # ValueError: Unknown finite element 'family'
+        field = Field("field", family="family")
+        with self.assertRaises(ValueError):
+            field.get_element(mesh1d())
+
+    def test_make_scalar_element_error3(self):
+        # ValueError: Order -1 invalid for 'Real' finite element
+        field = Field("field", family="Real", degree=-1)
+        with self.assertRaises(ValueError):
+            field.get_element(mesh1d())
+
     def test_field_alternative_real(self):
         field = Field(
             name="field",
-            mesh=mesh1d(),
             family="Real",
             degree=0,
         )
-        self.assertEqual(field.finite_element, real_element())
+        finite_element = field.get_element(mesh1d())
+        self.assertEqual(finite_element, real_element())
 
     def test_field_alternative_p1(self):
         field = Field(
             name="field",
-            mesh=mesh2d(),
             family="Lagrange",
             degree=1,
         )
-        self.assertEqual(field.finite_element, p1_element())
+        finite_element = field.get_element(mesh2d())
+        self.assertEqual(finite_element, p1_element())
 
 
 class TestInterrogation(unittest.TestCase):

--- a/test/test_field.py
+++ b/test/test_field.py
@@ -77,19 +77,16 @@ class TestGetElement(unittest.TestCase):
     """Test `get_element` method of Field class."""
 
     def test_make_scalar_element_error1(self):
-        # AttributeError: 'str' object has no attribute 'topology'
         field = Field("field", family="Real")
         with self.assertRaises(AttributeError):
             field.get_element("mesh")
 
     def test_make_scalar_element_error2(self):
-        # ValueError: Unknown finite element 'family'
         field = Field("field", family="family")
         with self.assertRaises(ValueError):
             field.get_element(mesh1d())
 
     def test_make_scalar_element_error3(self):
-        # ValueError: Order -1 invalid for 'Real' finite element
         field = Field("field", family="Real", degree=-1)
         with self.assertRaises(ValueError):
             field.get_element(mesh1d())

--- a/test/test_function_data.py
+++ b/test/test_function_data.py
@@ -33,7 +33,7 @@ class BaseTestCases:
             end_time = 1.0
             self.num_subintervals = 2
             timesteps = [0.5, 0.25]
-            self.field = Field("field")
+            self.field = Field("field", family="Real")
             self.num_exports = [1, 2]
             self.mesh = UnitTriangleMesh()
             self.time_partition = TimePartition(
@@ -51,7 +51,7 @@ class BaseTestCases:
             end_time = 1.0
             self.num_subintervals = 1
             timesteps = [1.0]
-            self.field = Field("field")
+            self.field = Field("field", family="Real")
             self.num_exports = [1]
             self.mesh = UnitTriangleMesh()
             self.time_partition = TimePartition(
@@ -368,7 +368,7 @@ class TestTransferFunctionData(BaseTestCases.TestFunctionData):
             self.time_partition.end_time,
             self.time_partition.num_subintervals,
             self.time_partition.timesteps,
-            [Field("different_field")],
+            [Field("different_field", family="Real")],
         )
         target_function_spaces = {
             "different_field": [

--- a/test/test_mesh_seq.py
+++ b/test/test_mesh_seq.py
@@ -30,9 +30,9 @@ class BaseClasses:
         """
 
         def setUp(self):
-            self.field = Field("field")
-            self.time_partition = TimePartition(1.0, 2, [0.5, 0.5], Field("field"))
-            self.time_interval = TimeInterval(1.0, [0.5], Field("field"))
+            self.field = Field("field", family="Real")
+            self.time_partition = TimePartition(1.0, 2, [0.5, 0.5], self.field)
+            self.time_interval = TimeInterval(1.0, [0.5], self.field)
 
         def trivial_mesh(self, dim):
             try:

--- a/test/test_metric.py
+++ b/test/test_metric.py
@@ -66,10 +66,10 @@ class TestMetricNormalisation(BaseClasses.MetricTestCase):
 
     def setUp(self):
         super().setUp()
-        self.time_partition = TimeInterval(1.0, 1.0, Field("u"))
+        self.time_partition = TimeInterval(1.0, 1.0, Field("u", family="Real"))
 
     def test_time_partition_length_error(self):
-        time_partition = TimePartition(1.0, 2, [0.5, 0.5], Field("u"))
+        time_partition = TimePartition(1.0, 2, [0.5, 0.5], Field("u", family="Real"))
         mp = {"dm_plex_metric_target_complexity": 1.0}
         with self.assertRaises(ValueError) as cm:
             space_time_normalise([self.simple_metric], time_partition, [mp])

--- a/test/test_parallel.py
+++ b/test/test_parallel.py
@@ -10,7 +10,7 @@ from goalie.time_partition import TimeInterval
 @pytest.mark.parallel(nprocs=2)
 def test_counting_2d():
     assert COMM_WORLD.size == 2
-    time_interval = TimeInterval(1.0, [0.5], Field("field"))
+    time_interval = TimeInterval(1.0, [0.5], Field("field", family="Real"))
     mesh_seq = MeshSeq(time_interval, [UnitSquareMesh(3, 3)])
     assert mesh_seq.count_elements() == [18]
     assert mesh_seq.count_vertices() == [16]
@@ -19,7 +19,7 @@ def test_counting_2d():
 @pytest.mark.parallel(nprocs=2)
 def test_counting_3d():
     assert COMM_WORLD.size == 2
-    time_interval = TimeInterval(1.0, [0.5], Field("field"))
+    time_interval = TimeInterval(1.0, [0.5], Field("field", family="Real"))
     mesh_seq = MeshSeq(time_interval, [UnitCubeMesh(3, 3, 3)])
     assert mesh_seq.count_elements() == [162]
     assert mesh_seq.count_vertices() == [64]

--- a/test/test_time_partition.py
+++ b/test/test_time_partition.py
@@ -252,16 +252,16 @@ class TestStringFormatting(BaseTestCase):
     def test_time_partition1_repr(self):
         expected = (
             "TimePartition(end_time=1.0, num_subintervals=1,"
-            " timesteps=[0.5], field_metadata=[Field('field', <R0 on a interval>,"
-            " solved_for=True, unsteady=True)])"
+            " timesteps=[0.5], field_metadata=[Field('field', <R? on a unknown cell"
+            " type>, solved_for=True, unsteady=True)])"
         )
         self.assertEqual(repr(self.get_time_partition(1)), expected)
 
     def test_time_partition2_repr(self):
         expected = (
             "TimePartition(end_time=1.0, num_subintervals=2,"
-            " timesteps=[0.25, 0.5], field_metadata=[Field('field', <R0 on a interval>,"
-            " solved_for=True, unsteady=True)])"
+            " timesteps=[0.25, 0.5], field_metadata=[Field('field', <R? on a unknown"
+            " cell type>, solved_for=True, unsteady=True)])"
         )
         self.assertEqual(repr(self.get_time_partition(2)), expected)
 
@@ -269,14 +269,14 @@ class TestStringFormatting(BaseTestCase):
         expected = (
             "TimePartition(end_time=1.0, num_subintervals=4,"
             " timesteps=[0.125, 0.25, 0.125, 0.25], field_metadata=[Field('field',"
-            " <R0 on a interval>, solved_for=True, unsteady=True)])"
+            " <R? on a unknown cell type>, solved_for=True, unsteady=True)])"
         )
         self.assertEqual(repr(self.get_time_partition(4)), expected)
 
     def test_time_interval_repr(self):
         expected = (
             "TimeInterval(end_time=1.0, timestep=0.5, field_metadata=[Field('field',"
-            " <R0 on a interval>, solved_for=True, unsteady=True)])"
+            " <R? on a unknown cell type>, solved_for=True, unsteady=True)])"
         )
         time_interval = TimeInterval(self.end_time, [0.5], self.field_metadata_list)
         self.assertEqual(repr(time_interval), expected)
@@ -284,7 +284,7 @@ class TestStringFormatting(BaseTestCase):
     def test_time_instant_repr(self):
         expected = (
             "TimeInstant(time=1.0, field_metadata=[Field('field',"
-            " <R0 on a interval>, solved_for=True, unsteady=True)])"
+            " <R? on a unknown cell type>, solved_for=True, unsteady=True)])"
         )
         time_instant = TimeInstant(self.field_metadata_list, time=self.end_time)
         self.assertEqual(repr(time_instant), expected)

--- a/test/test_time_partition.py
+++ b/test/test_time_partition.py
@@ -15,7 +15,7 @@ class BaseTestCase(unittest.TestCase):
 
     def setUp(self):
         self.end_time = 1.0
-        self.field = Field("field")
+        self.field = Field("field", family="Real")
         self.field_metadata_list = [self.field]
         self.field_metadata_dict = {"field": self.field}
 
@@ -123,7 +123,7 @@ class TestExceptions(BaseTestCase):
 
     def test_inconsistent_fieldname_valueerror(self):
         with self.assertRaises(ValueError) as cm:
-            TimeInstant({"field1": Field("field2")})
+            TimeInstant({"field1": Field("field2", family="Real")})
         msg = "Inconstent field names passed as field_metadata."
         self.assertEqual(str(cm.exception), msg)
 
@@ -182,7 +182,7 @@ class TestSetup(BaseTestCase):
 
     def test_time_instant_eq_negative(self):
         time_instant1 = TimeInstant(self.field, time=1.0)
-        time_instant2 = TimeInstant(Field("f"), time=1.0)
+        time_instant2 = TimeInstant(Field("f", family="Real"), time=1.0)
         self.assertFalse(time_instant1 == time_instant2)
 
     def test_time_instant_ne_positive(self):


### PR DESCRIPTION
See the comment chain in https://github.com/mesh-adaptation/goalie/pull/296#discussion_r2030088537. This branch merges into that one.

Instead of passing the `mesh` to `Field.__init__` and constructing a finite element during initialisation, this PR introduces `get_element` and `get_function_space` methods to `Field` that take the mesh as an argument and return the element and fspace, respectively.