### PR TITLE
Account for Fields not solved for

### DIFF
--- a/goalie/adjoint.py
+++ b/goalie/adjoint.py
@@ -200,6 +200,11 @@ class AdjointMeshSeq(MeshSeq):
         :returns: list of solve blocks
         :rtype: :class:`list` of :class:`pyadjoint.block.Block`\s
         """
+        if not self.field_metadata[fieldname].solved_for:
+            raise ValueError(
+                f"Cannot retrieve solve blocks for field '{fieldname}' because it isn't"
+                " solved for."
+            )
         blocks = pyadjoint.get_working_tape().get_blocks()
         if len(blocks) == 0:
             self.warning("Tape has no blocks!")
@@ -523,7 +528,9 @@ class AdjointMeshSeq(MeshSeq):
                     )
 
             # Update adjoint solver kwargs
-            for fieldname in self.field_names:
+            for fieldname, field in self.field_metadata.items():
+                if not field.solved_for:
+                    continue
                 for block in self.get_solve_blocks(fieldname, i):
                     block.adj_kwargs.update(adj_solver_kwargs)
 
@@ -543,6 +550,9 @@ class AdjointMeshSeq(MeshSeq):
 
             # Loop over prognostic variables
             for fieldname, field in self.field_metadata.items():
+                if not field.solved_for:
+                    continue
+
                 # Get solve blocks
                 solve_blocks = self.get_solve_blocks(fieldname, i)
                 num_solve_blocks = len(solve_blocks)

--- a/goalie/field.py
+++ b/goalie/field.py
@@ -56,7 +56,7 @@ class Field:
                 raise ValueError(
                     "The finite_element and vector arguments cannot be used in"
                     " conjunction."
-            )
+                )
         elif kwargs.get("family") is None:
             raise ValueError("Either the finite_element or family must be specified.")
         self.finite_element = finite_element

--- a/test/test_field.py
+++ b/test/test_field.py
@@ -55,8 +55,9 @@ class TestExceptions(unittest.TestCase):
     def test_insufficient_arguments(self):
         with self.assertRaises(ValueError) as cm:
             Field("field")
-        msg = ("Either the finite_element or family must be specified.")
+        msg = "Either the finite_element or family must be specified."
         self.assertEqual(str(cm.exception), msg)
+
 
 class TestInit(unittest.TestCase):
     """Test initialisation of Field class."""
@@ -77,6 +78,23 @@ class TestInit(unittest.TestCase):
         self.assertEqual(field.finite_element, p1_element())
         self.assertFalse(field.solved_for)
         self.assertFalse(field.unsteady)
+
+    def test_field_alternative_real(self):
+        field = Field(
+            name="field",
+            family="Real",
+            degree=0,
+        )
+        self.assertEqual(field.get_element(mesh1d()), real_element())
+
+    def test_field_alternative_p1(self):
+        field = Field(
+            name="field",
+            family="Lagrange",
+            degree=1,
+        )
+        self.assertEqual(field.get_element(mesh2d()), p1_element())
+
 
 class TestGetElement(unittest.TestCase):
     """Test `get_element` method of Field class."""


### PR DESCRIPTION
Partial rework of #292.
Towards #289.

Following the recent addition of the `Field` class, this PR accounts for its `solved_for` attribute. `Field`s that are not solved for can be skipped in the adjoint solver. Unit tests are included.