### PR TITLE
Store gradient values in dict

### DIFF
--- a/goalie/adjoint.py
+++ b/goalie/adjoint.py
@@ -544,9 +544,10 @@ class AdjointMeshSeq(MeshSeq):
 
                 # Compute the gradient on the first subinterval
                 if i == 0 and compute_gradient:
-                    self._gradient = controls.delist(
-                        [control.get_derivative() for control in controls]
-                    )
+                    self._gradient = {
+                        field: control.get_derivative()
+                        for field, control in zip(self.field_names, controls)
+                    }
 
             # Loop over prognostic variables
             for fieldname, field in self.field_metadata.items():

--- a/test/adjoint/test_gradient.py
+++ b/test/adjoint/test_gradient.py
@@ -175,7 +175,7 @@ class TestGradientComputation(unittest.TestCase):
         mesh_seq.solve_adjoint(compute_gradient=True)
         self.assertTrue(
             np.allclose(
-                mesh_seq.gradient[0].dat.data,
+                mesh_seq.gradient["field"].dat.data,
                 mesh_seq.expected_gradient(),
             )
         )
@@ -202,7 +202,7 @@ class TestGradientComputation(unittest.TestCase):
         mesh_seq.solve_adjoint(compute_gradient=True)
         self.assertTrue(
             np.allclose(
-                mesh_seq.gradient[0].dat.data,
+                mesh_seq.gradient["field"].dat.data,
                 mesh_seq.expected_gradient(),
             )
         )
@@ -229,7 +229,7 @@ class TestGradientComputation(unittest.TestCase):
         mesh_seq.solve_adjoint(compute_gradient=True)
         self.assertTrue(
             np.allclose(
-                mesh_seq.gradient[0].dat.data,
+                mesh_seq.gradient["field"].dat.data,
                 mesh_seq.expected_gradient(),
             )
         )
@@ -256,7 +256,7 @@ class TestGradientComputation(unittest.TestCase):
         mesh_seq.solve_adjoint(compute_gradient=True)
         self.assertTrue(
             np.allclose(
-                mesh_seq.gradient[0].dat.data,
+                mesh_seq.gradient["field"].dat.data,
                 mesh_seq.expected_gradient(),
             )
         )


### PR DESCRIPTION
Partial rework of #292.
Towards #289.

This PR stores gradient values in a dictionary, rather than a list. This is more intuitive, user-friendly, and makes more sense, given the general approach to accessing and handling fields in Goalie.