### PR TITLE
Make Sphinx happy

### DIFF
--- a/demos/burgers_time_integrated.py
+++ b/demos/burgers_time_integrated.py
@@ -1,5 +1,5 @@
 # Adjoint Burgers equation with a time integrated QoI
-# ======================================================
+# ===================================================
 #
 # So far, we only considered a quantity of interest corresponding to a spatial integral
 # at the end time. For some problems, it is more suitable to have a QoI which integrates


### PR DESCRIPTION
`demos/burgers_time_integrated.py` doesn't show up in the docs ( https://mesh-adaptation.github.io/docs/goalie/index.html ) because of the syntax issue. This PR fixes it.