### PR TITLE
Avoid use of `.vector()`

### DIFF
--- a/goalie/go_mesh_seq.py
+++ b/goalie/go_mesh_seq.py
@@ -107,9 +107,7 @@ class GoalOrientedMeshSeq(AdjointMeshSeq):
                     # Skip solution fields since they are stored separately
                     if coeff.name().split("_old")[0] in self.function_spaces:
                         continue
-                    if not np.allclose(
-                        coeff.vector().array(), init_coeff.vector().array()
-                    ):
+                    if not np.allclose(coeff.dat.data_ro, init_coeff.dat.data_ro):
                         if coeff_idx not in self._changed_form_coeffs[fieldname]:
                             self._changed_form_coeffs[fieldname][coeff_idx] = {
                                 0: deepcopy(init_coeff)
@@ -379,7 +377,7 @@ class GoalOrientedMeshSeq(AdjointMeshSeq):
                 for indicator in by_mesh:
                     if absolute_value:
                         indicator.interpolate(abs(indicator))
-                    estimator += dt * indicator.vector().gather().sum()
+                    estimator += dt * indicator.dat.global_data.sum()
         return estimator
 
     def check_estimator_convergence(self):

--- a/goalie/mesh_seq.py
+++ b/goalie/mesh_seq.py
@@ -192,7 +192,7 @@ class MeshSeq:
                 nv = self.vertex_counts[0][i]
                 qm = QualityMeasure(mesh)
                 ar = qm("aspect_ratio")
-                mar = ar.vector().gather().max()
+                mar = ar.dat.global_data.max()
                 self.debug(
                     f"{i}: {nc:7d} cells, {nv:7d} vertices,  max aspect ratio {mar:.2f}"
                 )
@@ -348,7 +348,7 @@ class MeshSeq:
                 if logger.level == DEBUG:
                     next(solver_gen)
                     f, f_ = self.field_functions[next(iter(self.field_functions))]
-                    if np.array_equal(f.vector().array(), f_.vector().array()):
+                    if np.array_equal(f.dat.data_ro, f_.dat.data_ro):
                         self.debug(
                             "Current and lagged solutions are equal. Does the"
                             " solver yield before updating lagged solutions?"
@@ -398,9 +398,9 @@ class MeshSeq:
                     for fieldname in self.field_functions
                 }
             )
-        assert (
-            self._function_spaces_consistent()
-        ), "Meshes and function spaces are inconsistent"
+        assert self._function_spaces_consistent(), (
+            "Meshes and function spaces are inconsistent"
+        )
 
     @property
     def function_spaces(self):
@@ -624,14 +624,14 @@ class MeshSeq:
                     converged[i] = True
                     if len(self) == 1:
                         pyrint(
-                            f"Element count converged after {self.fp_iteration+1}"
+                            f"Element count converged after {self.fp_iteration + 1}"
                             " iterations under relative tolerance"
                             f" {self.params.element_rtol}."
                         )
                     else:
                         pyrint(
                             f"Element count converged on subinterval {i} after"
-                            f" {self.fp_iteration+1} iterations under relative"
+                            f" {self.fp_iteration + 1} iterations under relative"
                             f" tolerance {self.params.element_rtol}."
                         )
 

--- a/goalie/utility.py
+++ b/goalie/utility.py
@@ -43,7 +43,7 @@ def effectivity_index(error_indicator, Je):
     el = error_indicator.ufl_element()
     if not (el.family() == "Discontinuous Lagrange" and el.degree() == 0):
         raise ValueError("Error indicator must be P0.")
-    eta = error_indicator.vector().gather().sum()
+    eta = error_indicator.dat.global_data.sum()
     return np.abs(eta / Je)
 
 

--- a/test/adjoint/test_adjoint_mesh_seq.py
+++ b/test/adjoint/test_adjoint_mesh_seq.py
@@ -630,4 +630,4 @@ class TestDetectChangedCoefficients(BaseClasses.GoalOrientedBaseClass):
         changed_coeffs_dict = mesh_seq._changed_form_coeffs[self.field.name]
         coeff_idx = next(iter(changed_coeffs_dict))
         for export_idx, f in changed_coeffs_dict[coeff_idx].items():
-            self.assertTrue(f.vector().gather() == [1.0001 + export_idx * coeff_diff])
+            self.assertTrue(f.dat.global_data == [1.0001 + export_idx * coeff_diff])


### PR DESCRIPTION
Closes #316.

This was removed in https://github.com/firedrakeproject/firedrake/pull/4499.