### PR TITLE
Make use of `adapt_common`

### DIFF
--- a/goalie/adjoint.py
+++ b/goalie/adjoint.py
@@ -6,7 +6,7 @@ from functools import wraps
 
 import firedrake
 import numpy as np
-from animate.utility import norm
+from adapt_common.norms import norm
 from firedrake.adjoint import pyadjoint
 from firedrake.adjoint_utils.solving import get_solve_blocks
 from firedrake.petsc import PETSc

--- a/goalie/go_mesh_seq.py
+++ b/goalie/go_mesh_seq.py
@@ -7,8 +7,8 @@ from copy import deepcopy
 
 import numpy as np
 import ufl
+from adapt_common.reduction import function_data_sum
 from animate.interpolation import interpolate
-from animate.utility import function_data_sum
 from firedrake import Function, FunctionSpace, MeshHierarchy, TransferManager
 from firedrake.petsc import PETSc
 

--- a/goalie/mesh_seq.py
+++ b/goalie/mesh_seq.py
@@ -6,9 +6,10 @@ from collections.abc import Iterable
 
 import firedrake
 import numpy as np
+from adapt_common.reduction import function_data_max
 from animate.interpolation import transfer
 from animate.quality import QualityMeasure
-from animate.utility import Mesh, function_data_max
+from animate.utility import Mesh
 from firedrake.adjoint import pyadjoint
 from firedrake.mesh import MeshSequenceGeometry
 from firedrake.petsc import PETSc
@@ -407,9 +408,9 @@ class MeshSeq:
                     for fieldname in self.field_functions
                 }
             )
-        assert self._function_spaces_consistent(), (
-            "Meshes and function spaces are inconsistent"
-        )
+        assert (
+            self._function_spaces_consistent()
+        ), "Meshes and function spaces are inconsistent"
 
     @property
     def function_spaces(self):

--- a/goalie/mesh_seq.py
+++ b/goalie/mesh_seq.py
@@ -9,7 +9,6 @@ import numpy as np
 from adapt_common.reduction import function_data_max
 from animate.interpolation import transfer
 from animate.quality import QualityMeasure
-from animate.utility import Mesh
 from firedrake.adjoint import pyadjoint
 from firedrake.mesh import MeshSequenceGeometry
 from firedrake.petsc import PETSc
@@ -179,6 +178,13 @@ class MeshSeq:
         :type meshes: :class:`list` of :class:`firedrake.MeshGeometry`\s or
             :class:`firedrake.MeshGeometry`
         """
+
+        def Mesh(arg):
+            try:
+                return firedrake.Mesh(arg)
+            except TypeError:
+                return firedrake.Mesh(arg.coordinates)
+
         # TODO #122: Refactor to use the set method
         if not isinstance(meshes, list):
             meshes = [Mesh(meshes) for subinterval in self.subintervals]

--- a/goalie/utility.py
+++ b/goalie/utility.py
@@ -5,7 +5,7 @@ Utility functions and classes for mesh adaptation.
 import os
 
 import firedrake
-from animate.utility import function_data_sum
+from adapt_common.reduction import function_data_sum
 
 __all__ = ["AttrDict", "create_directory", "effectivity_index"]
 

--- a/test/adjoint/test_adjoint.py
+++ b/test/adjoint/test_adjoint.py
@@ -10,7 +10,7 @@ import unittest
 import numpy as np
 import pyadjoint
 import pytest
-from animate.utility import errornorm, norm
+from adapt_common.norms import errornorm, norm
 from firedrake.cofunction import Cofunction
 from firedrake.output.vtk_output import VTKFile
 from firedrake.utility_meshes import UnitTriangleMesh

--- a/test/adjoint/test_adjoint_mesh_seq.py
+++ b/test/adjoint/test_adjoint_mesh_seq.py
@@ -9,7 +9,7 @@ from unittest.mock import patch
 import pyadjoint
 import pytest
 import ufl
-from animate.utility import norm
+from adapt_common.norms import norm
 from finat.ufl import FiniteElement, VectorElement
 from firedrake.function import Function
 from firedrake.functionspace import FunctionSpace

--- a/test/test_metric.py
+++ b/test/test_metric.py
@@ -7,8 +7,8 @@ import unittest
 import numpy as np
 import pytest
 import sensors
+from adapt_common.norms import errornorm
 from animate.metric import RiemannianMetric
-from animate.utility import errornorm
 from firedrake.functionspace import TensorFunctionSpace
 from parameterized import parameterized
 from utility import mesh_for_sensors, uniform_mesh


### PR DESCRIPTION
The CI is currently failing because some of Animate's functionality has now been moved to `adapt_common`.
https://github.com/mesh-adaptation/docs/actions/runs/22083432965/job/63813103656

This PR updates Goalie accordingly.